### PR TITLE
feat: add message input component

### DIFF
--- a/src/features/message-input/index.ts
+++ b/src/features/message-input/index.ts
@@ -1,0 +1,1 @@
+export { MessageInput } from './ui/MessageInput';

--- a/src/features/message-input/ui/MessageInput.tsx
+++ b/src/features/message-input/ui/MessageInput.tsx
@@ -1,0 +1,230 @@
+import React, { useState, useRef, useEffect } from 'react';
+import data from '@emoji-mart/data';
+import Picker from '@emoji-mart/react';
+import type { Emoji } from '@emoji-mart/data';
+import type { DesignTokens } from '../../../shared/config/tokens';
+
+type Props = {
+  tokens: DesignTokens;
+  onSend?: (text: string) => void;
+};
+
+export const MessageInput: React.FC<Props> = ({ tokens, onSend }) => {
+  const [value, setValue] = useState('');
+  const [showEmoji, setShowEmoji] = useState(false);
+  const [showAttach, setShowAttach] = useState(false);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const emojiBtnRef = useRef<HTMLButtonElement>(null);
+  const attachBtnRef = useRef<HTMLButtonElement>(null);
+  const emojiPanelRef = useRef<HTMLDivElement>(null);
+  const attachPanelRef = useRef<HTMLDivElement>(null);
+
+  const maxHeight = typeof window !== 'undefined' ? window.innerHeight * 0.35 : 200;
+
+  const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setValue(e.target.value);
+    if (textareaRef.current) {
+      textareaRef.current.style.height = 'auto';
+      const next = Math.min(textareaRef.current.scrollHeight, maxHeight);
+      textareaRef.current.style.height = `${next}px`;
+      textareaRef.current.style.overflowY = textareaRef.current.scrollHeight > maxHeight ? 'auto' : 'hidden';
+    }
+  };
+
+  const handleSend = () => {
+    if (!value.trim()) return;
+    onSend?.(value);
+    setValue('');
+    if (textareaRef.current) {
+      textareaRef.current.style.height = 'auto';
+    }
+  };
+
+  const handleEmojiSelect = (emoji: Emoji & { native?: string }) => {
+    setValue((prev) => prev + (emoji.native || ''));
+    textareaRef.current?.focus();
+  };
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        setShowEmoji(false);
+        setShowAttach(false);
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, []);
+
+  useEffect(() => {
+    const onClick = (e: MouseEvent) => {
+      if (
+        showEmoji &&
+        emojiPanelRef.current &&
+        !emojiPanelRef.current.contains(e.target as Node) &&
+        !emojiBtnRef.current?.contains(e.target as Node)
+      ) {
+        setShowEmoji(false);
+      }
+      if (
+        showAttach &&
+        attachPanelRef.current &&
+        !attachPanelRef.current.contains(e.target as Node) &&
+        !attachBtnRef.current?.contains(e.target as Node)
+      ) {
+        setShowAttach(false);
+      }
+    };
+    document.addEventListener('mousedown', onClick);
+    return () => document.removeEventListener('mousedown', onClick);
+  }, [showEmoji, showAttach]);
+
+  return (
+    <div
+      className="px-6 pb-5 pt-3 flex justify-center border-t"
+      style={{
+        background: String(tokens.color['bg.input.container']),
+        borderColor: String(tokens.color['bg.panel.border']),
+        boxShadow: '0 -1px 2px rgba(17,19,21,0.06)'
+      }}
+    >
+      <div className="flex items-end w-full max-w-2xl gap-2 relative">
+        <div
+          className="flex items-end flex-1 relative"
+          style={{
+            background: String(tokens.color['bg.input.field']),
+            borderRadius: tokens.radius?.xl ? `${tokens.radius.xl}px` : undefined,
+            paddingLeft: tokens.space?.md,
+            paddingRight: tokens.space?.md,
+            paddingTop: tokens.space?.sm,
+            paddingBottom: tokens.space?.sm
+          }}
+        >
+          <button
+            ref={emojiBtnRef}
+            type="button"
+            onClick={() => {
+              setShowEmoji((v) => !v);
+              setShowAttach(false);
+            }}
+            className="mr-2 cursor-pointer flex items-center justify-center"
+            style={{
+              width: 24,
+              height: 24,
+              color: String(tokens.color['icon.normal']),
+              borderRadius: tokens.radius?.pill ? `${tokens.radius.pill}px` : undefined
+            }}
+          >
+            😊
+          </button>
+          {showEmoji && (
+            <div
+              ref={emojiPanelRef}
+              className="absolute"
+              style={{
+                bottom: `calc(100% + ${tokens.space?.sm}px)`,
+                left: 0,
+                zIndex: tokens.z?.panels,
+                background: String(tokens.color['bg.panel']),
+                border: `1px solid ${tokens.color['bg.panel.border']}`,
+                boxShadow: String(tokens.color['shadow.panel']),
+                borderRadius: tokens.radius?.lg ? `${tokens.radius.lg}px` : undefined
+              }}
+            >
+              <Picker data={data} onEmojiSelect={handleEmojiSelect} />
+            </div>
+          )}
+          <textarea
+            ref={textareaRef}
+            value={value}
+            onChange={handleChange}
+            placeholder="Message"
+            rows={1}
+            className="flex-1 bg-transparent focus:outline-none resize-none overflow-hidden"
+            style={{
+              color: String(tokens.color['text.primary']),
+              minHeight: 44,
+              maxHeight: maxHeight,
+              scrollbarWidth: 'thin'
+            }}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' && !e.shiftKey) {
+                e.preventDefault();
+                handleSend();
+              }
+            }}
+          />
+          <button
+            ref={attachBtnRef}
+            type="button"
+            onClick={() => {
+              setShowAttach((v) => !v);
+              setShowEmoji(false);
+            }}
+            className="ml-2 cursor-pointer flex items-center justify-center"
+            style={{
+              width: 24,
+              height: 24,
+              color: String(tokens.color['icon.accent']),
+              borderRadius: tokens.radius?.pill ? `${tokens.radius.pill}px` : undefined
+            }}
+          >
+            📎
+          </button>
+          {showAttach && (
+            <div
+              ref={attachPanelRef}
+              className="absolute"
+              style={{
+                bottom: `calc(100% + ${tokens.space?.sm}px)`,
+                right: 0,
+                zIndex: tokens.z?.panels,
+                background: String(tokens.color['bg.panel']),
+                border: `1px solid ${tokens.color['bg.panel.border']}`,
+                boxShadow: String(tokens.color['shadow.panel']),
+                borderRadius: tokens.radius?.lg ? `${tokens.radius.lg}px` : undefined,
+                width: 220
+              }}
+            >
+              <ul className="py-2">
+                {['Фото или видео', 'Файл', 'Checklist', 'Кошелёк'].map((item) => (
+                  <li
+                    key={item}
+                    className="px-4 py-2 cursor-pointer flex items-center gap-2 hover:bg-black/5"
+                    style={{ color: String(tokens.color['text.primary']) }}
+                  >
+                    <span style={{ color: String(tokens.color['icon.accent']) }}>•</span>
+                    {item}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </div>
+        <button
+          type="button"
+          onClick={handleSend}
+          disabled={!value.trim()}
+          className="flex items-center justify-center cursor-pointer flex-shrink-0"
+          style={{
+            width: 44,
+            height: 44,
+            borderRadius: tokens.radius?.pill ? `${tokens.radius.pill}px` : undefined,
+            background: String(
+              value.trim()
+                ? tokens.color['bg.send.enabled']
+                : tokens.color['bg.send.disabled']
+            ),
+            opacity: value.trim() ? 1 : 0.6,
+            color: '#fff'
+          }}
+        >
+          ✈️
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default MessageInput;
+

--- a/src/pages/chat/ChatPage.tsx
+++ b/src/pages/chat/ChatPage.tsx
@@ -1,9 +1,6 @@
 import React, { useRef, useState, useEffect } from 'react';
 import { observer } from 'mobx-react-lite';
 import { LayoutWithFloatingBg } from '../../shared/ui/LayoutWithFloatingBg';
-import data from '@emoji-mart/data';
-import Picker from '@emoji-mart/react';
-import type { Emoji } from '@emoji-mart/data';
 import { useChats } from '../../features/chats/hooks';
 import { chatStore } from '../../features/chats/model';
 import type { Chat } from '../../features/chats/api';
@@ -16,6 +13,7 @@ import { storyStore } from '../../features/stories/model';
 import { lightTokens, darkTokens } from '../../shared/config/tokens';
 import { natsStore } from '../../shared/nats/model';
 import { LoadingDots } from '../../shared/ui/LoadingDots';
+import { MessageInput } from '../../features/message-input';
 
   const ChatPage = observer(() => {
     useChats();
@@ -33,17 +31,12 @@ import { LoadingDots } from '../../shared/ui/LoadingDots';
   const [menuOpen, setMenuOpen] = useState(false);
   const [moreOpen, setMoreOpen] = useState(false);
   const [fabOpen, setFabOpen] = useState(false);
-  const [message, setMessage] = useState('');
   const [searchFocused, setSearchFocused] = useState(false);
-  const [showEmoji, setShowEmoji] = useState(false);
   const [storiesCollapsed, setStoriesCollapsed] = useState(false);
-  const textareaRef = useRef<HTMLTextAreaElement>(null);
   const storyRef = useRef<HTMLDivElement>(null);
   const tabRef = useRef<HTMLDivElement>(null);
   const burgerRef = useRef<HTMLButtonElement>(null);
   const menuRef = useRef<HTMLDivElement>(null);
-  const emojiBtnRef = useRef<HTMLButtonElement>(null);
-  const emojiPickerRef = useRef<HTMLDivElement>(null);
   const [chatSlides, setChatSlides] = useState<Chat[][]>([]);
   const [translate, setTranslate] = useState(0);
   const [isAnimating, setIsAnimating] = useState(false);
@@ -70,15 +63,15 @@ import { LoadingDots } from '../../shared/ui/LoadingDots';
 
   const TOKENS = theme === 'dark' ? darkTokens : lightTokens;
 
-  const themeVars: React.CSSProperties = {
-    // expose variables for inline usage
-    ['--primary-color' as any]: String(TOKENS.color['icon.accent']),
-    ['--surface-color' as any]: String(TOKENS.color['bg.app']),
-    ['--primary-text-color' as any]: String(TOKENS.color['text.primary']),
-    ['--secondary-text-color' as any]: String(TOKENS.color['text.secondary']),
-    ['--message-out-background-color' as any]: String(TOKENS.color['bg.message.out']),
-    ['--message-out-primary-color' as any]: theme === 'dark' ? '#ffffff' : String(TOKENS.color['text.primary']),
-    ['--light-filled-secondary-text-color' as any]: String(TOKENS.color['bg.input']),
+  const themeVars = {
+    '--primary-color': String(TOKENS.color['icon.accent']),
+    '--surface-color': String(TOKENS.color['bg.app']),
+    '--primary-text-color': String(TOKENS.color['text.primary']),
+    '--secondary-text-color': String(TOKENS.color['text.secondary']),
+    '--message-out-background-color': String(TOKENS.color['bg.message.out']),
+    '--message-out-primary-color':
+      theme === 'dark' ? '#ffffff' : String(TOKENS.color['text.primary']),
+    '--light-filled-secondary-text-color': String(TOKENS.color['bg.input']),
   } as React.CSSProperties;
 
     useEffect(() => {
@@ -103,40 +96,10 @@ import { LoadingDots } from '../../shared/ui/LoadingDots';
       return () => el.removeEventListener('wheel', handle);
     }, []);
 
-  const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-    setMessage(e.target.value);
-    if (textareaRef.current) {
-      textareaRef.current.style.height = 'auto';
-      textareaRef.current.style.height = `${textareaRef.current.scrollHeight}px`;
-    }
-  };
-
-  const handleEmojiSelect = (emoji: Emoji & { native?: string }) => {
-    setMessage((prev) => prev + (emoji.native || ''));
-    if (textareaRef.current) {
-      textareaRef.current.focus();
-    }
-  };
 
   const handleChatScroll = (e: React.UIEvent<HTMLDivElement>) => {
     setStoriesCollapsed(e.currentTarget.scrollTop > 0);
   };
-
-  useEffect(() => {
-    const handler = (e: MouseEvent) => {
-      if (
-        showEmoji &&
-        emojiPickerRef.current &&
-        !emojiPickerRef.current.contains(e.target as Node) &&
-        !emojiBtnRef.current?.contains(e.target as Node)
-      ) {
-        setShowEmoji(false);
-      }
-    };
-    document.addEventListener('mousedown', handler);
-    return () => document.removeEventListener('mousedown', handler);
-  }, [showEmoji]);
-
   useEffect(() => {
     const handler = (e: MouseEvent) => {
       if (
@@ -550,42 +513,7 @@ import { LoadingDots } from '../../shared/ui/LoadingDots';
                   ))}
                 </div>
               </div>
-              <div className="px-6 pb-5 pt-3 flex justify-center border-t" style={{ background: String(TOKENS.color['bg.header']), borderColor: String(TOKENS.color['border.muted']), boxShadow: String(TOKENS.elevation.card) }}>
-                <div className="flex items-end w-full max-w-2xl gap-2 relative">
-                  <div className="flex items-end flex-1 rounded-[20px] px-4 py-2 relative" style={{ background: String(TOKENS.color['bg.input']) }}>
-                    <div className="relative">
-                      <button
-                        ref={emojiBtnRef}
-                        type="button"
-                        onClick={() => setShowEmoji((v) => !v)}
-                        className="text-2xl mr-2 cursor-pointer"
-                        style={{ color: String(TOKENS.color['icon.normal']) }}
-                      >
-                        😊
-                      </button>
-                      {showEmoji && (
-                        <div
-                          ref={emojiPickerRef}
-                          className="absolute bottom-full left-0 mb-2 z-10"
-                        >
-                          <Picker data={data} onEmojiSelect={handleEmojiSelect} />
-                        </div>
-                      )}
-                    </div>
-                    <textarea
-                      ref={textareaRef}
-                      value={message}
-                      onChange={handleChange}
-                      placeholder="Message"
-                      rows={1}
-                      className="flex-1 bg-transparent focus:outline-none resize-none overflow-hidden"
-                      style={{ color: String(TOKENS.color['text.primary']) }}
-                    />
-                    <button className="text-xl ml-2 cursor-pointer" style={{ color: String(TOKENS.color['icon.normal']) }}>📎</button>
-                  </div>
-                  <button className="w-10 h-10 rounded-full flex items-center justify-center cursor-pointer" style={{ background: String(TOKENS.color['bg.unread.badge']), color: String(TOKENS.color['text.inverse']) }}>✈️</button>
-                </div>
-              </div>
+              <MessageInput tokens={TOKENS} />
             </>
           ) : (
             <div className="flex-1 flex items-center justify-center" style={{ color: String(TOKENS.color['text.secondary']) }}>

--- a/src/shared/config/tokens.ts
+++ b/src/shared/config/tokens.ts
@@ -4,6 +4,7 @@ export type DesignTokens = {
   space: Record<string, number>;
   font: Record<string, string | number>;
   elevation: Record<string, string>;
+  z: Record<string, number>;
 };
 
 export const lightTokens: DesignTokens = {
@@ -21,6 +22,12 @@ export const lightTokens: DesignTokens = {
     'bg.message.in': '#FFFFFF',
     'bg.message.out': '#E2FDD6',
     'bg.input': '#F4F4F4',
+    'bg.input.container': '#FFFFFF',
+    'bg.input.field': '#F4F4F4',
+    'bg.send.enabled': '#3390EC',
+    'bg.send.disabled': '#B9D7F6',
+    'bg.panel': 'rgba(255,255,255,0.96)',
+    'bg.panel.border': '#E6E6E6',
     'bg.unread.badge': '#3390EC',
     'bg.selection': 'rgba(0,136,204,0.08)',
     'border.muted': '#E6E6E6',
@@ -32,9 +39,12 @@ export const lightTokens: DesignTokens = {
     'text.inverse': '#FFFFFF',
     'icon.normal': '#6B6F76',
     'icon.accent': '#3390EC',
+    'hover.fill': 'rgba(0,0,0,0.06)',
+    'focus.ring': 'rgba(51,144,236,0.18)',
+    'shadow.panel': '0 12px 32px rgba(17,19,21,0.16)',
     shadow: 'rgba(17,19,21,0.08)'
   },
-  radius: { xs: 6, sm: 8, md: 12, lg: 16, xl: 20 },
+  radius: { xs: 6, sm: 8, md: 12, lg: 16, xl: 22, pill: 999 },
   space: { xxs: 4, xs: 6, sm: 8, md: 12, lg: 16, xl: 20, xxl: 24 },
   font: {
     family: `-apple-system, Segoe UI, Roboto, Arial, sans-serif`,
@@ -48,7 +58,8 @@ export const lightTokens: DesignTokens = {
   elevation: {
     card: '0 1px 2px rgba(17,19,21,0.06)',
     float: '0 8px 24px rgba(17,19,21,0.12)'
-  }
+  },
+  z: { input: 10, panels: 30, header: 40 }
 };
 
 // Minimal dark mapping (keeps our previous dark feel; can be refined)
@@ -66,6 +77,12 @@ export const darkTokens: DesignTokens = {
     'bg.message.in': '#1F2024',
     'bg.message.out': '#2E3A2C',
     'bg.input': '#22242A',
+    'bg.input.container': '#1C1D20',
+    'bg.input.field': '#22242A',
+    'bg.send.enabled': '#3390EC',
+    'bg.send.disabled': '#2E3136',
+    'bg.panel': 'rgba(28,29,32,0.96)',
+    'bg.panel.border': '#2E3136',
     'border.muted': '#2E3136',
     'border.message': '#2A2D33',
     'text.primary': '#FFFFFF',
@@ -73,6 +90,9 @@ export const darkTokens: DesignTokens = {
     'text.muted': '#8A9098',
     'icon.normal': '#A8AEB6',
     'icon.accent': '#77A8FF',
+    'hover.fill': 'rgba(255,255,255,0.08)',
+    'focus.ring': 'rgba(119,168,255,0.18)',
+    'shadow.panel': '0 12px 32px rgba(0,0,0,0.32)',
     shadow: 'rgba(0,0,0,0.35)'
   }
 };


### PR DESCRIPTION
## Summary
- add MessageInput feature with emoji picker, attachments menu, and send button
- extend design tokens for input and panel styling
- integrate MessageInput into chat page

## Testing
- `npm run lint` (fails: Unexpected any in existing nats files)
- `npx eslint src/features/message-input/ui/MessageInput.tsx src/features/message-input/index.ts src/pages/chat/ChatPage.tsx src/shared/config/tokens.ts`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68971f04886083229223490e1ef662d1