### PR TITLE
feat: restore sidebar panel designs

### DIFF
--- a/src/widgets/sidebar/ui/ChatsPanel.tsx
+++ b/src/widgets/sidebar/ui/ChatsPanel.tsx
@@ -1,17 +1,77 @@
 import { observer } from 'mobx-react-lite';
-import { chatStore } from '../../../features/chats/model';
+import { useChats } from '../../../features/chats/hooks';
+import { lightTokens } from '../../../shared/config/tokens';
 
 export const ChatsPanel = observer(() => {
+  const chatStore = useChats();
+  const TOKENS = lightTokens;
+
   return (
-    <div className="space-y-2">
+    <div className="flex-1 overflow-y-auto scrollbar-custom pt-2">
       {chatStore.chats.map((chat) => (
         <div
           key={chat.id}
-          className="cursor-pointer rounded p-2 hover:bg-neutral-100"
+          onClick={() => chatStore.selectChat(chat.id)}
+          className="px-3"
         >
-          {chat.name}
+          <div
+            className="flex items-center gap-3 px-3 cursor-pointer"
+            style={{
+              height: 72,
+              borderBottom: `1px solid ${TOKENS.color['border.muted']}`,
+              background:
+                chatStore.selectedChatId === chat.id
+                  ? (TOKENS.color['bg.sidebar.active'] as string)
+                  : 'transparent',
+              borderRadius: chatStore.selectedChatId === chat.id ? 12 : 0,
+            }}
+          >
+            <img
+              src={chat.avatar}
+              className="w-11 h-11 rounded-full object-cover"
+            />
+            <div className="flex-1 min-w-0">
+              <div className="flex justify-between items-center">
+                <span
+                  className="truncate"
+                  style={{
+                    fontWeight: 600,
+                    color: TOKENS.color['text.primary'] as string,
+                  }}
+                >
+                  {chat.name}
+                </span>
+                <span
+                  className="text-[12px]"
+                  style={{ color: TOKENS.color['text.muted'] as string }}
+                >
+                  {chat.lastMessageDate}
+                </span>
+              </div>
+              <div className="flex justify-between items-center">
+                <span
+                  className="text-[14px] truncate"
+                  style={{ color: TOKENS.color['text.secondary'] as string }}
+                >
+                  {chat.lastMessage}
+                </span>
+                {chat.unread > 0 && (
+                  <span
+                    className="ml-2 text-[12px] rounded-full px-2 py-[2px]"
+                    style={{
+                      background: TOKENS.color['bg.unread.badge'] as string,
+                      color: TOKENS.color['text.inverse'] as string,
+                    }}
+                  >
+                    {chat.unread}
+                  </span>
+                )}
+              </div>
+            </div>
+          </div>
         </div>
       ))}
     </div>
   );
 });
+

--- a/src/widgets/sidebar/ui/SearchPanel.tsx
+++ b/src/widgets/sidebar/ui/SearchPanel.tsx
@@ -1,11 +1,77 @@
-export function SearchPanel() {
+import { useState } from 'react';
+import { observer } from 'mobx-react-lite';
+import { useMenu } from '../../../features/menu/hooks';
+import { lightTokens } from '../../../shared/config/tokens';
+
+export const SearchPanel = observer(() => {
+  const menuStore = useMenu();
+  const [search, setSearch] = useState('');
+  const [focused, setFocused] = useState(false);
+  const [open, setOpen] = useState(false);
+  const TOKENS = lightTokens;
+
   return (
-    <div className="mb-4">
-      <input
-        type="text"
-        placeholder="Search"
-        className="w-full rounded border p-2"
-      />
+    <div
+      className="p-3 flex items-center gap-2 border-b relative"
+      style={{ borderColor: TOKENS.color['border.muted'] as string }}
+    >
+      <button
+        onClick={() => setOpen((v) => !v)}
+        className="w-9 h-9 rounded-full flex items-center justify-center cursor-pointer"
+        style={{ background: TOKENS.color['bg.input'] as string }}
+      >
+        ☰
+      </button>
+      <div className="relative flex-1">
+        <input
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          onFocus={() => setFocused(true)}
+          onBlur={() => setFocused(false)}
+          placeholder="Search"
+          className="w-full rounded-[20px] h-10 pl-10 pr-4 focus:outline-none placeholder-[#9AA0A6]"
+          style={{
+            background: TOKENS.color['bg.search'] as string,
+            color: TOKENS.color['text.primary'] as string,
+            border: focused
+              ? `1px solid ${TOKENS.color['icon.accent']}`
+              : '1px solid transparent',
+            boxShadow: focused
+              ? `0 0 0 3px ${TOKENS.color['focus.ring']}`
+              : 'none',
+          }}
+        />
+        <div
+          className="absolute left-3 top-1/2 -translate-y-1/2 text-sm"
+          style={{ color: TOKENS.color['icon.normal'] as string }}
+        >
+          🔍
+        </div>
+      </div>
+      {open && (
+        <div
+          className="absolute top-12 left-2 w-56 rounded-lg shadow-lg z-20 text-sm"
+          onMouseLeave={() => setOpen(false)}
+          style={{
+            backgroundColor: TOKENS.color['bg.header'] as string,
+            color: TOKENS.color['text.primary'] as string,
+            border: `1px solid ${TOKENS.color['border.muted']}`,
+            boxShadow: TOKENS.color['shadow.panel'] as string,
+          }}
+        >
+          {menuStore.items.map((item) => (
+            <div
+              key={item.id}
+              className="flex items-center gap-2 px-4 py-2 cursor-pointer hover:bg-neutral-100"
+              onClick={() => setOpen(false)}
+            >
+              <span>{item.icon}</span>
+              <span>{item.label}</span>
+            </div>
+          ))}
+        </div>
+      )}
     </div>
   );
-}
+});
+

--- a/src/widgets/sidebar/ui/Sidebar.tsx
+++ b/src/widgets/sidebar/ui/Sidebar.tsx
@@ -1,13 +1,24 @@
 import { SearchPanel } from './SearchPanel';
 import { StoriesPanel } from './StoriesPanel';
 import { ChatsPanel } from './ChatsPanel';
+import { lightTokens } from '../../../shared/config/tokens';
 
 export function Sidebar() {
+  const TOKENS = lightTokens;
+
   return (
-    <aside className="w-[340px] border-r p-4 space-y-4">
+    <aside
+      className="flex flex-col relative border-r"
+      style={{
+        width: 340,
+        background: TOKENS.color['bg.sidebar'] as string,
+        borderColor: TOKENS.color['border.muted'] as string,
+      }}
+    >
       <SearchPanel />
       <StoriesPanel />
       <ChatsPanel />
     </aside>
   );
 }
+

--- a/src/widgets/sidebar/ui/StoriesPanel.tsx
+++ b/src/widgets/sidebar/ui/StoriesPanel.tsx
@@ -1,24 +1,62 @@
 import { observer } from 'mobx-react-lite';
-import { storyStore } from '../../../features/stories/model';
+import { useStories } from '../../../features/stories/hooks';
+import { lightTokens } from '../../../shared/config/tokens';
 
 export const StoriesPanel = observer(() => {
-  return (
-    <div className="mb-4">
-      {storyStore.stories.length === 0 ? (
+  const storyStore = useStories();
+  const TOKENS = lightTokens;
+
+  if (storyStore.stories.length === 0) {
+    return (
+      <div
+        className="p-3 border-b"
+        style={{ borderColor: TOKENS.color['border.muted'] as string }}
+      >
         <div className="text-neutral-500">No stories</div>
-      ) : (
-        <ul className="flex space-x-2 overflow-x-auto">
-          {storyStore.stories.map((story) => (
-            <li key={story.id}>
-              <img
-                src={story.avatar}
-                alt={story.title}
-                className="h-12 w-12 rounded-full"
-              />
-            </li>
-          ))}
-        </ul>
-      )}
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="flex gap-4 overflow-x-auto hide-scrollbar px-3 py-2 border-b"
+      style={{
+        background: TOKENS.color['bg.story.strip'] as string,
+        borderColor: TOKENS.color['border.muted'] as string,
+      }}
+    >
+      {storyStore.stories.map((story) => {
+        const ringGradient = `linear-gradient(135deg, ${TOKENS.color['bg.story.ring.start']}, ${TOKENS.color['bg.story.ring.end']})`;
+        return (
+          <div
+            key={story.id}
+            className="flex flex-col items-center w-[64px] shrink-0"
+          >
+            <div
+              className="w-[64px] h-[64px] rounded-full p-[3px]"
+              style={{ background: ringGradient }}
+            >
+              <div
+                className="w-full h-full rounded-full p-[2px]"
+                style={{ background: '#fff' }}
+              >
+                <img
+                  src={story.avatar}
+                  alt={story.title}
+                  className="w-full h-full rounded-full object-cover"
+                />
+              </div>
+            </div>
+            <span
+              className="text-[12px] mt-1 truncate w-full text-center"
+              style={{ color: TOKENS.color['text.secondary'] as string }}
+            >
+              {story.title}
+            </span>
+          </div>
+        );
+      })}
     </div>
   );
 });
+


### PR DESCRIPTION
## Summary
- restore search panel with menu button and styled input
- reintroduce stories ring list in sidebar
- rebuild chats panel with avatars, previews and unread badges

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68973042fc4083228fb26b3382ab1f21