### PR TITLE
feat: cache avatar and fix settings panel scroll

### DIFF
--- a/src/features/profile/api.ts
+++ b/src/features/profile/api.ts
@@ -5,6 +5,7 @@ export interface Profile {
   about?: string | null;
   birthdayLabel?: string | null;
   avatarUrl?: string | null;
+  avatarCacheDataUrl?: string | null;
 }
 
 // Mock REST API call

--- a/src/features/profile/model.ts
+++ b/src/features/profile/model.ts
@@ -24,10 +24,12 @@ class ProfileStore {
             about: cached.about ?? null,
             birthdayLabel: cached.birthdayLabel ?? null,
             avatarUrl: cached.avatarUrl ?? null,
+            avatarCacheDataUrl: cached.avatarCacheDataUrl ?? null,
           };
-          // @ts-ignore keep cache DataURL for UI if present
-          (this.profile as any).avatarCacheDataUrl = (cached as any).avatarCacheDataUrl || null;
         });
+        if (cached.avatarUrl && !cached.avatarCacheDataUrl) {
+          void this.cacheAvatarFromUrl(cached.avatarUrl);
+        }
         return;
       }
       const data = await fetchProfile();
@@ -43,10 +45,12 @@ class ProfileStore {
         birthdayLabel: data.birthdayLabel ?? null,
         avatarUrl: data.avatarUrl ?? null,
         // keep empty cache on first fetch
-        // @ts-ignore
         avatarCacheDataUrl: null,
       };
       await saveProfileToDB(dto);
+      if (data.avatarUrl) {
+        void this.cacheAvatarFromUrl(data.avatarUrl);
+      }
     } finally {
       this.loading = false;
     }
@@ -55,8 +59,7 @@ class ProfileStore {
   async setAvatar({ remoteUrl, cacheDataUrl }: { remoteUrl: string; cacheDataUrl: string }) {
     if (!this.profile) return;
     this.profile.avatarUrl = remoteUrl;
-    // @ts-ignore ephemeral cache for UI
-    (this.profile as any).avatarCacheDataUrl = cacheDataUrl;
+    this.profile.avatarCacheDataUrl = cacheDataUrl;
     const dto: ProfileDTO = {
       id: 'me',
       displayName: this.profile.displayName,
@@ -65,10 +68,24 @@ class ProfileStore {
       about: this.profile.about ?? null,
       birthdayLabel: this.profile.birthdayLabel ?? null,
       avatarUrl: this.profile.avatarUrl ?? null,
-      // @ts-ignore persist cached DataURL
       avatarCacheDataUrl: cacheDataUrl,
-    } as any;
+    };
     await saveProfileToDB(dto);
+  }
+
+  private async cacheAvatarFromUrl(url: string) {
+    try {
+      const res = await fetch(url);
+      const blob = await res.blob();
+      const reader = new FileReader();
+      const dataUrl: string = await new Promise((resolve) => {
+        reader.onload = () => resolve(reader.result as string);
+        reader.readAsDataURL(blob);
+      });
+      await this.setAvatar({ remoteUrl: url, cacheDataUrl: dataUrl });
+    } catch (err) {
+      console.error('failed to cache avatar', err);
+    }
   }
 }
 

--- a/src/shared/ui/LayoutWithFloatingBg.tsx
+++ b/src/shared/ui/LayoutWithFloatingBg.tsx
@@ -17,7 +17,6 @@ interface LayoutProps {
 
 export const LayoutWithFloatingBg = observer(function LayoutWithFloatingBg({ children, noFrame = false }: LayoutProps) {
   const showAnims = appSettingsStore.state.animations;
-  const theme = appSettingsStore.state.theme;
   return (
     <div className="flex flex-col min-h-screen relative bg-gradient-to-br from-purple-900/80 via-indigo-900/80 to-blue-900/80 text-white overflow-hidden">
 

--- a/src/widgets/chat-sidebar/ui/SearchBar.tsx
+++ b/src/widgets/chat-sidebar/ui/SearchBar.tsx
@@ -7,6 +7,7 @@ import { presignForUpload } from '../../../shared/media/api';
 import { profileStore } from '../../../features/profile/model';
 import { settingsPanelStore } from '../../../features/settings-panel/model';
 import Avatar from '../../../shared/ui/Avatar';
+import type { MenuItem } from '../../../features/menu/api';
 
 interface Props {
   search: string;
@@ -77,8 +78,8 @@ const SearchBar = observer(({ search, onSearch, storiesCollapsed }: Props) => {
           }}
           className="absolute top-12 left-2 w-56 bg-white border border-gray-200 rounded-lg shadow-lg z-20 text-sm text-black"
         >
-          {appSettingsStore.state.version === 'A'
-            ? menuStore.flattenedItems.concat([{ id: 'chatbg', icon: '🖼️', label: 'Выбрать фон чата' } as any]).map((item) => (
+            {appSettingsStore.state.version === 'A'
+              ? menuStore.flattenedItems.concat([{ id: 'chatbg', icon: '🖼️', label: 'Выбрать фон чата' } as MenuItem]).map((item) => (
                 <div
                   key={item.id}
                   className="flex items-center gap-2 px-4 py-2 hover:bg-gray-100 cursor-pointer"
@@ -108,7 +109,9 @@ const SearchBar = observer(({ search, onSearch, storiesCollapsed }: Props) => {
                 >
                   {item.id === 'user' ? (
                     <>
-                      {profileStore.profile?.avatarUrl ? (
+                      {profileStore.profile?.avatarCacheDataUrl ? (
+                        <img src={profileStore.profile.avatarCacheDataUrl} className="w-8 h-8 rounded-full object-cover" />
+                      ) : profileStore.profile?.avatarUrl ? (
                         <img src={profileStore.profile.avatarUrl} className="w-8 h-8 rounded-full object-cover" />
                       ) : (
                         <Avatar name={profileStore.profile?.displayName || 'U'} size={32} />
@@ -137,7 +140,7 @@ const SearchBar = observer(({ search, onSearch, storiesCollapsed }: Props) => {
                   )}
                 </div>
               ))
-            : menuStore.renderedItems.concat([{ id: 'chatbg', icon: '🖼️', label: 'Выбрать фон чата' } as any]).map((item) => (
+            : menuStore.renderedItems.concat([{ id: 'chatbg', icon: '🖼️', label: 'Выбрать фон чата' } as MenuItem]).map((item) => (
                 <div
                   key={item.id}
                   className="relative group"
@@ -173,7 +176,9 @@ const SearchBar = observer(({ search, onSearch, storiesCollapsed }: Props) => {
                   >
                     {item.id === 'user' ? (
                       <>
-                        {profileStore.profile?.avatarUrl ? (
+                        {profileStore.profile?.avatarCacheDataUrl ? (
+                          <img src={profileStore.profile.avatarCacheDataUrl} className="w-8 h-8 rounded-full object-cover" />
+                        ) : profileStore.profile?.avatarUrl ? (
                           <img src={profileStore.profile.avatarUrl} className="w-8 h-8 rounded-full object-cover" />
                         ) : (
                           <Avatar name={profileStore.profile?.displayName || 'U'} size={32} />
@@ -189,7 +194,7 @@ const SearchBar = observer(({ search, onSearch, storiesCollapsed }: Props) => {
                   </div>
                   {item.id === 'more' && moreOpen && (
                     <div className="absolute top-0 left-full -ml-2 w-full bg-white border border-gray-200 rounded-lg shadow-lg text-sm text-black">
-                      {item.children?.concat([{ id: 'chatbg', icon: '🖼️', label: 'Выбрать фон чата' } as any]).map((child) => (
+                      {item.children?.concat([{ id: 'chatbg', icon: '🖼️', label: 'Выбрать фон чата' } as MenuItem]).map((child) => (
                         <div
                           key={child.id}
                           className="flex items-center gap-2 px-4 py-2 hover:bg-gray-100 cursor-pointer"
@@ -212,7 +217,9 @@ const SearchBar = observer(({ search, onSearch, storiesCollapsed }: Props) => {
                         >
                           {child.id === 'user' ? (
                             <>
-                              {profileStore.profile?.avatarUrl ? (
+                              {profileStore.profile?.avatarCacheDataUrl ? (
+                                <img src={profileStore.profile.avatarCacheDataUrl} className="w-8 h-8 rounded-full object-cover" />
+                              ) : profileStore.profile?.avatarUrl ? (
                                 <img src={profileStore.profile.avatarUrl} className="w-8 h-8 rounded-full object-cover" />
                               ) : (
                                 <Avatar name={profileStore.profile?.displayName || 'U'} size={32} />

--- a/src/widgets/settings-panel/ui/SettingsPanel.tsx
+++ b/src/widgets/settings-panel/ui/SettingsPanel.tsx
@@ -59,7 +59,7 @@ const MenuDots = () => (
 );
 
 const ProfileTop = observer(() => {
-  const p: any = profileStore.profile as any;
+  const p = profileStore.profile;
   return (
     <div className="px-3 pt-3">
       <div className="w-full aspect-square rounded-md bg-gray-500/40 overflow-hidden flex items-center justify-center">
@@ -193,7 +193,7 @@ const SettingsPanel = observer(() => {
   return (
     <div className="absolute inset-0 z-30">
       <div
-        className="absolute top-0 right-0 bottom-0 left-0 bg-black border-l border-white/20 will-change-transform"
+        className="absolute top-0 right-0 bottom-0 left-0 bg-black border-l border-white/20 will-change-transform flex flex-col"
         style={{
           transform: slideIn ? 'translateX(0%)' : 'translateX(100%)',
           transition: 'transform 420ms ease',


### PR DESCRIPTION
## Summary
- cache profile avatars locally and reuse them in the burger menu
- make settings panel scrollable and tidy layout
- remove unused theme variable to satisfy build

## Testing
- `npm run lint` *(fails: Unexpected any in unrelated modules)*
- `npm run build`
- `npm test` *(fails: expect is not defined)*

------
https://chatgpt.com/codex/tasks/task_b_689b40deaba88322b4c2fdf1dc323771