### PR TITLE
feat: add theme tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This project uses React + TypeScript + Vite with a feature-sliced structure. Below is a concise map of the chat data model, UI composition, scroll behavior, and how IndexedDB is populated in the background.
 
+## Theming
+
+Light and dark theme tokens live in `src/assets/theme.light.css` and `src/assets/theme.dark.css`. They are imported via `src/assets/tokens.css` and applied by toggling the `data-theme` attribute on `:root`.
+
 ## Structure Overview
 
 - app entry: `src/main.tsx`; routes: `src/app/routes.tsx`; global styles: `src/index.css`.

--- a/src/assets/theme.dark.css
+++ b/src/assets/theme.dark.css
@@ -1,0 +1,26 @@
+:root[data-theme="dark"] {
+  --bg:           #0B1220;
+  --surface:      #0F172A;
+  --surface-2:    #111827;
+  --outline:      #2A3444;
+  --text-primary: #E6EDF7;
+  --text-muted:   #96A2B8;
+
+  --primary:      #4098FF;
+  --primary-600:  #2B7BE0;
+  --success:      #2BBB66;
+  --success-50:   #123B26;
+
+  --glass: rgba(20,28,44,.84);
+  --glass-border: #243348;
+  --shadow: 0 16px 50px rgba(0,0,0,.35);
+
+  --msg-select: color-mix(in srgb, var(--primary) 22%, var(--surface));
+
+  --accent-left:  #8B5CF6;
+  --accent-right: #38BDF8;
+  --ring: #60A5FA;
+  --pill-pct-idle: 18%;
+  --pill-pct-hover: 28%;
+  --pill-pct-active: 36%;
+}

--- a/src/assets/theme.light.css
+++ b/src/assets/theme.light.css
@@ -1,0 +1,31 @@
+:root[data-theme="light"] {
+  /* Нейтрали */
+  --bg:           #F6F9FE;
+  --surface:      #FFFFFF;
+  --surface-2:    #F1F5FB;
+  --outline:      #E1E8F5;
+  --text-primary: #0B1220;
+  --text-muted:   #637087;
+
+  /* Акценты */
+  --primary:      #1C7BEF;
+  --primary-600:  #1769CE;
+  --success:      #2BBB66;
+  --success-50:   #EAFBF2;
+
+  /* Стеклянные панели */
+  --glass: rgba(255,255,255,.88);
+  --glass-border: var(--outline);
+  --shadow: 0 10px 40px rgba(16,24,40,.12);
+
+  /* Подсветка строки сообщения при R-click */
+  --msg-select: color-mix(in srgb, var(--primary) 10%, #FFFFFF);
+
+  /* Кнопки шапки */
+  --accent-left:  #8B5CF6;
+  --accent-right: #38BDF8;
+  --ring: #60A5FA;
+  --pill-pct-idle: 12%;
+  --pill-pct-hover: 20%;
+  --pill-pct-active: 28%;
+}

--- a/src/assets/tokens.css
+++ b/src/assets/tokens.css
@@ -1,23 +1,2 @@
-:root {
-  --accent-left:  #8B5CF6;
-  --accent-right: #38BDF8;
-  --ring: #60A5FA;
-}
-
-:root[data-theme="light"] {
-  --header-bg: #F8FAFC;
-  --text: #0B1220;
-  --icon-on-surface: #0B1220;
-  --pill-pct-idle: 12%;
-  --pill-pct-hover: 20%;
-  --pill-pct-active: 28%;
-}
-
-:root[data-theme="dark"] {
-  --header-bg: #0B1220;
-  --text: #E5E7EB;
-  --icon-on-surface: #FFFFFF;
-  --pill-pct-idle: 18%;
-  --pill-pct-hover: 28%;
-  --pill-pct-active: 36%;
-}
+@import "./theme.light.css";
+@import "./theme.dark.css";

--- a/src/index.css
+++ b/src/index.css
@@ -9,9 +9,7 @@
 @tailwind utilities;
 
 /* Header icon button styling */
-.app-header {
-  background: var(--header-bg);
-}
+.app-header{ background: var(--header-bg, var(--surface)); }
 
 .icon-btn {
   width: 36px;
@@ -29,13 +27,13 @@
 .header-right .icon-btn { --accent: var(--accent-right); }
 
 .icon-btn {
-  background: color-mix(in srgb, var(--header-bg) calc(100% - var(--pill-pct-idle)), var(--accent) var(--pill-pct-idle));
+  background: color-mix(in srgb, var(--header-bg, var(--surface)) calc(100% - var(--pill-pct-idle)), var(--accent) var(--pill-pct-idle));
 }
 .icon-btn:hover {
-  background: color-mix(in srgb, var(--header-bg) calc(100% - var(--pill-pct-hover)), var(--accent) var(--pill-pct-hover));
+  background: color-mix(in srgb, var(--header-bg, var(--surface)) calc(100% - var(--pill-pct-hover)), var(--accent) var(--pill-pct-hover));
 }
 .icon-btn:active {
-  background: color-mix(in srgb, var(--header-bg) calc(100% - var(--pill-pct-active)), var(--accent) var(--pill-pct-active));
+  background: color-mix(in srgb, var(--header-bg, var(--surface)) calc(100% - var(--pill-pct-active)), var(--accent) var(--pill-pct-active));
 }
 .icon-btn:focus-visible {
   box-shadow: 0 0 0 2px var(--ring);
@@ -239,14 +237,13 @@ body {
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  --emoji-fonts: "Apple Color Emoji","Segoe UI Emoji","Noto Color Emoji","EmojiOne Color","Segoe UI Symbol";
 }
 
 .twemoji { width: 1.25em; height: 1.25em; vertical-align: -0.2em; }
 
 /* ВАЖНО: это правило должно идти ПОСЛЕ tailwind base/components/utilities */
 .emoji-text, textarea, input {
-  font-family: var(--emoji-fonts), system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif !important;
+  font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif !important;
 }
 
 a {


### PR DESCRIPTION
## Summary
- add light and dark theme token files
- reference theme tokens from global stylesheet and drop emoji font override
- document theme token usage

## Testing
- `npm run lint` (fails: @typescript-eslint/no-explicit-any and related errors)
- `npm run build` (fails: TS errors in stories and settings panel)
- `npm run a11y:contrast`


------
https://chatgpt.com/codex/tasks/task_b_689cee8e8d2c8322a4553776973c00fd