### PR TITLE
feat: integrate animated emoji picker

### DIFF
--- a/src/emoji/index.ts
+++ b/src/emoji/index.ts
@@ -2,4 +2,5 @@ export { AnimatedEmoji } from './AnimatedEmoji';
 export { EmojiPicker } from './EmojiPicker';
 export { insertEmojiAtCaret } from './insertEmojiAtCaret';
 export { EMOJI, CATEGORY_INDEX, resolveEmojiSrc } from './emojiMap';
+export { nameToNative } from './nameToNative';
 export type { Tone, EmojiKind, EmojiEntry } from './emojiMap';

--- a/src/emoji/nameToNative.ts
+++ b/src/emoji/nameToNative.ts
@@ -1,0 +1,19 @@
+import { resolveEmojiSrc, Tone } from './emojiMap';
+
+/**
+ * Convert an emoji shortcode and tone to the corresponding native Unicode string.
+ */
+export function nameToNative(name: string, tone: Tone = 'default'): string | null {
+  const resolved = resolveEmojiSrc(name, tone);
+  if (!resolved) return null;
+  const file = resolved.src.split('/').pop()?.split('.')[0];
+  if (!file) return null;
+  try {
+    return file
+      .split('_')
+      .map((cp) => String.fromCodePoint(parseInt(cp, 16)))
+      .join('');
+  } catch {
+    return null;
+  }
+}

--- a/src/entities/message/ui/Message.tsx
+++ b/src/entities/message/ui/Message.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef, useState } from 'react';
 import type { MessageModel } from '../types';
 import MessageContent from './parts/MessageContent';
 import MessageMeta from './parts/MessageMeta';
@@ -8,6 +8,7 @@ import { messageStore } from '../../../features/messages/model';
 import SvgAppendix from './parts/SvgAppendix';
 import Reactions from './parts/Reactions';
 import appSettingsStore from '../../../shared/config/appSettings';
+import { EmojiPicker, nameToNative, Tone } from '../../../emoji';
 
 export interface MessageProps {
   message: MessageModel;
@@ -15,8 +16,38 @@ export interface MessageProps {
 
 const Message: React.FC<MessageProps> = ({ message }) => {
   const mine = message.sender === 'me';
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [pickerTop, setPickerTop] = useState(0);
+
+  const handleContextMenu = (e: React.MouseEvent) => {
+    e.preventDefault();
+    const rect = containerRef.current?.getBoundingClientRect();
+    const y = rect ? e.clientY - rect.top : 0;
+    setPickerTop(y);
+    setPickerOpen(true);
+  };
+
+  const handlePick = ({ name, tone }: { name: string; tone: Tone }) => {
+    const native = nameToNative(name, tone);
+    if (native) {
+      messageStore.toggleReaction(message.conversationId, message.id, native);
+    }
+    setPickerOpen(false);
+  };
+
   return (
-    <div className={`flex ${mine ? 'justify-end' : 'justify-start'} group`}>
+    <div
+      ref={containerRef}
+      className={`flex ${mine ? 'justify-end' : 'justify-start'} group relative`}
+      onContextMenu={handleContextMenu}
+    >
+      {pickerOpen && (
+        <div
+          className="absolute inset-0 bg-black/40"
+          onClick={() => setPickerOpen(false)}
+        />
+      )}
       <div className="flex items-end gap-2 max-w-[70%]">
         {!mine && <ActionButton />}
         <div
@@ -37,6 +68,17 @@ const Message: React.FC<MessageProps> = ({ message }) => {
       <div className={`${mine ? 'mr-2' : 'ml-2'}`}>
         <QuickReaction onReact={(emoji) => messageStore.toggleReaction(message.conversationId, message.id, emoji)} />
       </div>
+      {pickerOpen && (
+        <div className="absolute left-full ml-2" style={{ top: pickerTop }}>
+          <EmojiPicker
+            open={pickerOpen}
+            onClose={() => setPickerOpen(false)}
+            onPick={handlePick}
+            defaultTone="default"
+            persistToneKey="emoji_last_tone"
+          />
+        </div>
+      )}
     </div>
   );
 };

--- a/src/pages/chat/ChatPage.tsx
+++ b/src/pages/chat/ChatPage.tsx
@@ -1,9 +1,8 @@
 import React, { useRef, useState, useEffect } from 'react';
 import { observer } from 'mobx-react-lite';
 import { LayoutWithFloatingBg } from '../../shared/ui/LayoutWithFloatingBg';
-import type { Emoji } from '@emoji-mart/data';
 import TwemojiText from '../../shared/emoji/TwemojiText';
-import EmojiPanel from '../../widgets/emoji-panel/ui/EmojiPanel';
+import { EmojiPicker, nameToNative, Tone } from '../../emoji';
 import { chatStore } from '../../features/chats/model';
 import appSettingsStore from '../../shared/config/appSettings';
 import { natsStore } from '../../shared/nats/model';
@@ -84,15 +83,15 @@ const ChatPage = observer(() => {
     return () => clearTimeout(t);
   }, [message, chatStore.selectedChatId]);
 
-  // 👉 новый handleEmojiSelect: вставка в TwemojiInput, плюс обновление стейта
+  // 👉 новый handleEmojiPick: вставка в TwemojiInput, плюс обновление стейта
   const ZWSP = '\u200B';
 
-  const handleEmojiSelect = (emoji: Emoji & { native?: string }) => {
-    const native = emoji.native || '';
+  const handleEmojiPick = ({ name, tone }: { name: string; tone: Tone }) => {
+    const native = nameToNative(name, tone);
     if (!native) return;
-    // вставляем эмодзи с разделителями: [ZWSP][EMOJI][ZWSP]
     inputRef.current?.insert(`${ZWSP}${native}${ZWSP}`);
     inputRef.current?.focus();
+    setShowEmoji(false);
   };
 
   // Sidebar scroll state handled inside ChatSidebar
@@ -356,12 +355,14 @@ const ChatPage = observer(() => {
                         <div
                           ref={emojiPickerRef}
                           className="absolute bottom-full left-0 mb-2 z-10"
-                          onMouseLeave={() => setShowEmoji(false)}
                         >
-                          <EmojiPanel
-                            onEmojiSelect={(native) =>
-                              handleEmojiSelect({ native } as any)
-                            }
+                          <EmojiPicker
+                            open={showEmoji}
+                            anchorEl={emojiBtnRef.current || undefined}
+                            onClose={() => setShowEmoji(false)}
+                            onPick={handleEmojiPick}
+                            defaultTone="default"
+                            persistToneKey="emoji_last_tone"
                           />
                         </div>
                       )}


### PR DESCRIPTION
## Summary
- replace legacy emoji panel with animated picker in chat composer
- show animated emoji picker on message right-click with overlay and reaction hook
- add helper to resolve emoji shortcodes to native characters

## Testing
- `npm run lint`
- `npm run build` *(fails: Cannot find name 'vi', Module '@testing-library/react' has no exported member 'screen', etc.)*

------
https://chatgpt.com/codex/tasks/task_b_689d9b500a48832282a226069b2cb8dc