### PR TITLE
fix emoji picker range event and lottie loading

### DIFF
--- a/src/emoji/AnimatedEmoji.tsx
+++ b/src/emoji/AnimatedEmoji.tsx
@@ -43,14 +43,25 @@ export function AnimatedEmoji({
 
   useEffect(() => {
     if (!divRef.current || kind !== 'lottie') return;
-    const anim = lottie.loadAnimation({
-      container: divRef.current,
-      path: src,
-      loop: true,
-      autoplay: shouldAnimate,
-    });
-    if (!shouldAnimate) anim.goToAndStop(0, true);
-    return () => anim.destroy();
+    let anim: ReturnType<typeof lottie.loadAnimation> | null = null;
+    let cancelled = false;
+    fetch(src)
+      .then((r) => r.json())
+      .then((data) => {
+        if (cancelled || !divRef.current) return;
+        anim = lottie.loadAnimation({
+          container: divRef.current,
+          animationData: data,
+          loop: true,
+          autoplay: shouldAnimate,
+        });
+        if (!shouldAnimate) anim.goToAndStop(0, true);
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+      anim?.destroy();
+    };
   }, [src, kind, shouldAnimate]);
 
   if (!resolved) return null;

--- a/src/emoji/EmojiPicker.tsx
+++ b/src/emoji/EmojiPicker.tsx
@@ -139,7 +139,7 @@ export function EmojiPicker({
         style={{ height: 300 }}
         overscan={overscan}
         groupCounts={groupCounts}
-        onRangeChanged={({ startIndex }) => setActiveTab(groupIndexFromItem(startIndex))}
+        rangeChanged={({ startIndex }) => setActiveTab(groupIndexFromItem(startIndex))}
         components={{
           List: forwardRef<HTMLDivElement>((props, ref) => (
             <div {...props} ref={ref} role="grid" />


### PR DESCRIPTION
## Summary
- use `rangeChanged` callback in emoji picker
- load lottie animations via fetch to avoid responseText errors

## Testing
- `npm run lint`
- `npm run build` *(fails: TS errors in unrelated files)*
- `npm test` *(fails: @vitejs/plugin-react can't detect preamble)*

------
https://chatgpt.com/codex/tasks/task_b_689daeade26483228ff382ea9202c79e