### PR TITLE
fix: open emoji picker from chat button

### DIFF
--- a/src/pages/chat/ChatPage.tsx
+++ b/src/pages/chat/ChatPage.tsx
@@ -359,7 +359,6 @@ const ChatPage = observer(() => {
                         >
                           <EmojiPicker
                             open={showEmoji}
-                            anchorEl={emojiBtnRef.current || undefined}
                             onClose={() => setShowEmoji(false)}
                             onPick={handleEmojiPick}
                             defaultTone="default"


### PR DESCRIPTION
## Summary
- ensure emoji picker toggles from chat emoji button by removing unused anchor element

## Testing
- `npm run lint`
- `npm run build` *(fails: Cannot find name 'vi', React declared but value is never read, etc.)*

------
https://chatgpt.com/codex/tasks/task_b_689db0989db48322b48602fab69ab5da