### PR TITLE
fix: improve emoji picker layout

### DIFF
--- a/src/emoji/EmojiPicker.tsx
+++ b/src/emoji/EmojiPicker.tsx
@@ -162,11 +162,8 @@ export function EmojiPicker({
           return (
             <div
               role="row"
-              style={{
-                display: 'grid',
-                gridTemplateColumns: `repeat(${cols}, ${gridCellSize}px)`,
-                width: '100%',
-              }}
+              className="emoji-picker__row"
+              style={{ '--cell-size': `${gridCellSize}px` } as React.CSSProperties}
             >
               {row.map((token) => {
                 const [name, toneToken] = token.split('|') as [string, Tone?];
@@ -176,6 +173,7 @@ export function EmojiPicker({
                     type="button"
                     role="gridcell"
                     aria-label={name}
+                    className="emoji-picker__emoji"
                     style={{ width: gridCellSize, height: gridCellSize }}
                     onClick={() => handlePick(name, toneToken as Tone)}
                     onContextMenu={(e) => {

--- a/src/index.css
+++ b/src/index.css
@@ -60,6 +60,24 @@
   border-radius: 6px;
 }
 
+.emoji-picker__row {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, var(--cell-size));
+  width: 100%;
+}
+
+.emoji-picker__emoji {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 6px;
+  transition: background-color 0.12s ease;
+}
+
+.emoji-picker__emoji:hover {
+  background: rgba(0, 0, 0, 0.1);
+}
+
 .emoji-picker__footer {
   display: flex;
   justify-content: space-between;


### PR DESCRIPTION
## Summary
- ensure emojis wrap across picker width
- highlight emoji buttons on hover for better feedback

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_689ddada06e08322a23e6cb9b788bda0