### PR TITLE
fix: render emoji grid on hover

### DIFF
--- a/src/emoji/EmojiPicker.tsx
+++ b/src/emoji/EmojiPicker.tsx
@@ -74,7 +74,7 @@ export function EmojiPicker({
         left: alignRect ? alignRect.left : anchorRect.left,
       });
     }
-  }, [open, anchorEl, alignEl, containerRef]);
+  }, [open, anchorEl, alignEl, containerRef, cols]);
 
   useEffect(() => {
     if (!open) return;
@@ -142,6 +142,7 @@ export function EmojiPicker({
         ))}
       </div>
       <GroupedVirtuoso
+        key={cols}
         ref={virtuosoRef}
         style={{ height: 300 }}
         overscan={overscan}

--- a/src/emoji/virtualization.ts
+++ b/src/emoji/virtualization.ts
@@ -13,9 +13,16 @@ export function useGridColumns(cellSize: number) {
   const [cols, setCols] = useState(1);
   useEffect(() => {
     if (!ref.current) return;
-    const ro = new ResizeObserver((entries) => {
-      const width = entries[0].contentRect.width;
+
+    const update = (width: number) => {
       setCols(Math.max(1, Math.floor(width / cellSize)));
+    };
+
+    // Set initial columns based on current width to avoid a blank grid
+    update(ref.current.getBoundingClientRect().width);
+
+    const ro = new ResizeObserver((entries) => {
+      update(entries[0].contentRect.width);
     });
     ro.observe(ref.current);
     return () => ro.disconnect();


### PR DESCRIPTION
## Summary
- ensure emoji picker initializes column count so grid renders immediately
- recalc picker layout when column count changes

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_689de2c2d4a88322b12fe1ba9a24ef2a