### PR TITLE
fix: render emoji picker categories correctly

### DIFF
--- a/src/emoji/EmojiPicker.tsx
+++ b/src/emoji/EmojiPicker.tsx
@@ -6,7 +6,7 @@ import { CATEGORY_INDEX, Tone } from './emojiMap';
 import { TonePalette } from './TonePalette';
 import { useEmojiUsage } from './useEmojiUsage';
 import { toRows, useGridColumns } from './virtualization';
-import { categoryIconShortcodes } from './categoryIcons';
+import { categoryIcons } from './categoryIcons';
 
 const SECTION_LABELS: Record<string, string> = {
   recent: 'Недавние',
@@ -148,11 +148,7 @@ export function EmojiPicker({
             }}
             title={SECTION_LABELS[g]}
           >
-            <AnimatedEmoji
-              name={categoryIconShortcodes[g] ?? ':smile:'}
-              size={20}
-              animate={false}
-            />
+            {categoryIcons[g] ?? '❓'}
           </button>
         ))}
       </div>

--- a/src/emoji/categoryIcons.ts
+++ b/src/emoji/categoryIcons.ts
@@ -1,13 +1,13 @@
 // keys strictly match CATEGORY_INDEX
-export const categoryIconShortcodes: Record<string, string> = {
-  recent: ':alarm-clock:',
-  smileys_and_emotions: ':smile:',
-  people: ':raised-hand:',
-  animals_and_nature: ':dog:',
-  food_and_drink: ':hot-beverage:',
-  travel_and_places: ':automobile:',
-  activities_and_events: ':trophy:',
-  objects: ':light-bulb:',
-  symbols: ':musical-notes:',
-  flags: ':white-flag:',
+export const categoryIcons: Record<string, string> = {
+  recent: '🕒',
+  smileys_and_emotions: '😊',
+  people: '🧑',
+  animals_and_nature: '🐾',
+  food_and_drink: '🍔',
+  travel_and_places: '🚗',
+  activities_and_events: '🏆',
+  objects: '💡',
+  symbols: '🔣',
+  flags: '🚩',
 };

--- a/src/emoji/index.ts
+++ b/src/emoji/index.ts
@@ -4,6 +4,6 @@ export { insertEmojiAtCaret } from './insertEmojiAtCaret';
 export { EMOJI, CATEGORY_INDEX, resolveEmojiSrc } from './emojiMap';
 export { useEmojiUsage } from './useEmojiUsage';
 export { emojiConfig } from './config';
-export { categoryIconShortcodes } from './categoryIcons';
+export { categoryIcons } from './categoryIcons';
 export type { UsageRow } from './useEmojiUsage';
 export type { Tone, EmojiKind, EmojiEntry } from './emojiMap';


### PR DESCRIPTION
## Summary
- display emoji picker tabs using direct emoji icons
- export categoryIcons mapping for category lookups

## Testing
- `npm test` *(fails: @vitejs/plugin-react can't detect preamble)*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_689df836b2bc832291e8bdc5bbe5a370