### PR TITLE
feat: enable animated emojis in picker

### DIFF
--- a/src/emoji/AnimatedEmoji.tsx
+++ b/src/emoji/AnimatedEmoji.tsx
@@ -28,9 +28,9 @@ export function AnimatedEmoji({
   const divRef = useRef<HTMLDivElement>(null);
 
   const resolved = resolveEmojiSrc(name, skinTone);
-  if (!resolved) return null;
-
-  const { kind, src, meta } = resolved;
+  const kind = resolved?.kind;
+  const src = resolved?.src;
+  const meta = resolved?.meta;
   const shouldAnimate = animate && !reducedMotion;
 
   const baseStyle: CSSProperties = {
@@ -42,7 +42,7 @@ export function AnimatedEmoji({
 
   // Lottie
   useEffect(() => {
-    if (!divRef.current || kind !== 'lottie') return;
+    if (!divRef.current || kind !== 'lottie' || !src) return;
 
     let anim: ReturnType<typeof lottie.loadAnimation> | null = null;
     let cancelled = false;
@@ -71,6 +71,8 @@ export function AnimatedEmoji({
       anim?.destroy();
     };
   }, [src, kind, shouldAnimate]);
+
+  if (!resolved) return null;
 
   if (kind === 'lottie') {
     return (

--- a/src/emoji/EmojiPicker.tsx
+++ b/src/emoji/EmojiPicker.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, forwardRef, useLayoutEffect, useMemo } from 'react';
+import { useEffect, useRef, useState, forwardRef, useLayoutEffect, useMemo, CSSProperties } from 'react';
 import { GroupedVirtuoso, GroupedVirtuosoHandle } from 'react-virtuoso';
 import { AnimatedEmoji } from './AnimatedEmoji';
 import { CATEGORY_INDEX, Tone } from './emojiMap';
@@ -172,8 +172,8 @@ export function EmojiPicker({
       style={{
         top: position.top,
         left: position.left,
-        ['--emoji-gap' as any]: '8px',
-      }}
+        '--emoji-gap': '8px',
+      } as CSSProperties}
     >
       {/* Tabs */}
       <div role="tablist" className="emoji-picker__tabs">

--- a/src/emoji/config.ts
+++ b/src/emoji/config.ts
@@ -1,4 +1,4 @@
 export const emojiConfig = {
   animateSingleEmoji: true,
-  pickerAnimations: false,
+  pickerAnimations: true,
 };


### PR DESCRIPTION
## Summary
- enable emoji animations inside picker via config
- refactor AnimatedEmoji hook and remove implicit any from picker style

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_689e2ef669d88322896db2d152ce98ac