### PR TITLE
fix: ensure rlottie wasm loads correctly

### DIFF
--- a/src/emoji/AnimatedEmoji.tsx
+++ b/src/emoji/AnimatedEmoji.tsx
@@ -1,13 +1,11 @@
 import { CSSProperties, useEffect, useRef, useState } from 'react';
 import {
   createPlayer,
-  disposePlayer,
   isSupported as lottieSupported,
 } from '@tamtam-chat/lottie-player';
-import { 
-  createAdvancedLottiePlayer, 
+import {
   checkDecoderSupport,
-  SUPPORT 
+  SUPPORT
 } from './AdvancedLottiePlayer';
 import { resolveEmojiSrc, Tone } from './emojiMap';
 
@@ -41,7 +39,6 @@ export function AnimatedEmoji({
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const [failed, setFailed] = useState(false);
   const [decoderSupport, setDecoderSupport] = useState<any>(null);
-  const [useAdvanced, setUseAdvanced] = useState(false);
 
   const resolved = resolveEmojiSrc(name, skinTone);
   const kind = resolved?.kind;
@@ -56,11 +53,7 @@ export function AnimatedEmoji({
     if (useAdvancedPlayer) {
       checkDecoderSupport().then(support => {
         setDecoderSupport(support);
-        // Используем расширенный плеер если поддерживаются Web Workers и OffscreenCanvas
-        setUseAdvanced(support.offscreenCanvas && SUPPORT.webWorkers);
       });
-    } else {
-      setUseAdvanced(false);
     }
   }, [useAdvancedPlayer]);
   

--- a/src/emoji/index.ts
+++ b/src/emoji/index.ts
@@ -22,4 +22,5 @@ export {
 export type { UsageRow } from './useEmojiUsage';
 export type { Tone, EmojiKind, EmojiEntry } from './emojiMap';
 export type { LottiePlayer, LottiePlayerOptions } from './AdvancedLottiePlayer';
-export type { DecoderConfig, EmojiPickerInitOptions } from './nativeDecoders';
+export type { DecoderConfig } from './nativeDecoders';
+export type { EmojiPickerInitOptions } from './init';

--- a/src/emoji/nativeDecoders.ts
+++ b/src/emoji/nativeDecoders.ts
@@ -100,26 +100,30 @@ export class NativeDecoderLoader {
   private async loadDecoder(name: 'rlottie' | 'skottie', config: any): Promise<any> {
     try {
       console.log(`Загружаем декодер ${name}...`);
-      
+
+      // Для rlottie необходимо настроить путь к WASM до загрузки скрипта
+      if (name === 'rlottie') {
+        (window as any).Module = {
+          ...(window as any).Module,
+          locateFile: (path: string) => {
+            console.log(`rlottie ищет файл: ${path}`);
+            if (path.endsWith('.wasm')) {
+              console.log(`Перенаправляем WASM на: ${config.wasmUrl}`);
+              return config.wasmUrl;
+            }
+            return path;
+          },
+        };
+      }
+
       // Загружаем скрипт
       await this.loadScript(config.url);
-      
-      // Для rlottie настраиваем Module.locateFile
+
+      // Дополнительная настройка и проверка для rlottie
       if (name === 'rlottie' && (window as any).Module) {
         const module = (window as any).Module;
-        console.log('Настраиваем Module.locateFile для rlottie');
-        
-        module.locateFile = (path: string) => {
-          console.log(`rlottie ищет файл: ${path}`);
-          if (path.endsWith(".wasm")) {
-            console.log(`Перенаправляем WASM на: ${config.wasmUrl}`);
-            return config.wasmUrl;
-          }
-          return path;
-        };
-        
         console.log('Module.locateFile настроен:', module.locateFile);
-        
+
         // Инициализируем runtime
         if (module.onRuntimeInitialized) {
           await new Promise<void>((resolve) => {
@@ -130,12 +134,12 @@ export class NativeDecoderLoader {
             };
           });
         }
-        
+
         // Проверяем WASM файл
         if (config.wasmUrl) {
           await this.loadWasm(config.wasmUrl);
         }
-        
+
         // Ждем инициализации rlottie
         console.log('Ждем инициализации rlottie...');
         await new Promise<void>((resolve) => {
@@ -149,13 +153,13 @@ export class NativeDecoderLoader {
           };
           checkRlottie();
         });
-        
+
         // Создаем wrapper для совместимости
         if ((window as any).Module && (window as any).rlottie) {
           console.log('rlottie Module найден, создаем wrapper');
           const module = (window as any).Module;
           console.log('Доступные Module функции:', Object.keys(module).filter(key => key.startsWith('_')));
-          
+
           // Создаем wrapper объект
           const rlottieWrapper = {
             createAnimation: (data: any, options: any) => {
@@ -330,21 +334,6 @@ export class NativeDecoderLoader {
   /**
    * Загружает Web Worker
    */
-  private async loadWorker(url: string): Promise<void> {
-    try {
-      // Проверяем поддержку Web Workers
-      if (typeof Worker === 'undefined') {
-        throw new Error('Web Workers не поддерживаются');
-      }
-      
-      // Создаем worker для проверки
-      const worker = new Worker(url);
-      worker.terminate(); // Сразу завершаем для проверки
-    } catch (error) {
-      console.warn('Не удалось загрузить Web Worker:', error);
-    }
-  }
-
   /**
    * Проверяет, загружен ли декодер
    */


### PR DESCRIPTION
## Summary
- configure rlottie wasm path before script load
- re-export emoji picker init options from init module
- tidy animated emoji hook imports

## Testing
- `npm run lint` *(fails: Unexpected any errors)*
- `npm run build`
- `npm test` *(fails: @vitejs/plugin-react can't detect preamble)*

------
https://chatgpt.com/codex/tasks/task_b_689f760ec8fc832291453ad5fc6baf4a