### PR TITLE
fix: configure lottie worker

### DIFF
--- a/src/emoji/init.ts
+++ b/src/emoji/init.ts
@@ -5,6 +5,8 @@
 
 import { autoLoadDecoders, checkNativeDecoderSupport } from './nativeDecoders';
 import { emojiConfig } from './config';
+import workerUrl from '@tamtam-chat/lottie-player/dist/worker?url';
+import { updateConfig as updateLottiePlayerConfig } from '@tamtam-chat/lottie-player';
 
 // Интерфейс для конфигурации инициализации
 export interface EmojiPickerInitOptions {
@@ -172,6 +174,13 @@ export class EmojiPickerInitializer {
     
     if (this.options.enableWasmDecoder && typeof WebAssembly !== 'undefined') {
       emojiConfig.wasmDecoder = true;
+    }
+
+    // Настраиваем worker для стандартного плеера Lottie
+    try {
+      updateLottiePlayerConfig({ workerUrl });
+    } catch (error) {
+      this.log('warn', 'Не удалось обновить конфигурацию Lottie плеера:', error);
     }
 
     this.log('info', 'Конфигурация обновлена:', emojiConfig);


### PR DESCRIPTION
## Summary
- configure default lottie worker during emoji initialization to prevent runtime errors

## Testing
- `npm run lint` *(fails: Unexpected any. Specify a different type)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_689f791e635883228496aadd080dadba