### PR TITLE
feat: use wasm decoder worker for animated emoji

### DIFF
--- a/src/emoji/AnimatedEmoji.tsx
+++ b/src/emoji/AnimatedEmoji.tsx
@@ -5,7 +5,8 @@ import {
 } from '@tamtam-chat/lottie-player';
 import {
   checkDecoderSupport,
-  SUPPORT
+  SUPPORT,
+  createAdvancedLottiePlayer
 } from './AdvancedLottiePlayer';
 import { resolveEmojiSrc, Tone } from './emojiMap';
 
@@ -150,6 +151,25 @@ export function AnimatedEmoji({
               
               if (player) {
                 console.log(`Нативный декодер инициализирован для ${name}`);
+              }
+            } else if (decoderSupport?.wasm) {
+              console.log(`[${name}] Нативные декодеры недоступны, пробуем wasm-декодер через worker`);
+              try {
+                player = await createAdvancedLottiePlayer({
+                  canvas,
+                  movie: src,
+                  loop: true,
+                  autoplay: true,
+                  width: size,
+                  height: size,
+                  id: src,
+                  useOffscreenCanvas: true,
+                  useWasmDecoder: true,
+                });
+                console.log(`WASM плеер инициализирован для ${name}`);
+              } catch (err) {
+                console.warn(`[${name}] WASM плеер не удался:`, err);
+                player = null;
               }
             } else {
               console.log(`[${name}] Нативные декодеры недоступны, используем стандартный плеер`);


### PR DESCRIPTION
## Summary
- fallback to WASM decoder worker when native emoji decoders are unavailable

## Testing
- `npm run lint` *(fails: Unexpected any, react-hooks/exhaustive-deps, react-refresh warnings)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_689f7e8c9f4c8322bb22ce38b8697a54