### PR TITLE
fix: load rlottie from script tag

### DIFF
--- a/src/emoji/nativeDecoders.ts
+++ b/src/emoji/nativeDecoders.ts
@@ -117,13 +117,9 @@ export class NativeDecoderLoader {
         };
       }
 
-      // Загружаем скрипт или ESM модуль
-      if (name === 'rlottie') {
-        const mod = await import(/* @vite-ignore */ config.url);
-        (window as any).rlottie = mod.default || mod;
-      } else {
-        await this.loadScript(config.url);
-      }
+      // Загружаем скрипт. rlottie размещён в `public`, поэтому его нужно подключать
+      // через тег <script>, а не через `import`, иначе Vite не сможет обработать файл
+      await this.loadScript(config.url);
 
       // Загружаем Worker если указан и поддерживается
       if (config.workerUrl && checkNativeDecoderSupport().webWorkers) {


### PR DESCRIPTION
## Summary
- load rlottie decoder via script tag instead of import to avoid Vite public import error

## Testing
- `npm run lint` *(fails: unexpected any in existing files)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_689f8f8ee5e48322be20df7ecd7aaaa2