### PR TITLE
Bootstrap Flutter voice-first editor foundation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,18 @@
+# Flutter/Dart
+.dart_tool/
+.packages
+.pub-cache/
+build/
+coverage/
+.idea/
+.vscode/
+android/
+ios/
+web/
+macos/
+windows/
+linux/
+**/Generated.xcconfig
+**/*.iml
+*.lock
+pubspec.lock

--- a/README.md
+++ b/README.md
@@ -1,1 +1,54 @@
+# Voicebook
 
+Voicebook — мультиплатформенный (Android + Web/PWA) голос‑первый редактор книг на Flutter 3.22+ и Dart 3. Проект включает модульную архитектуру, Riverpod для управления состоянием и go_router для навигации.
+
+## Структура каталогов
+
+```
+lib/
+  app/                 # точка входа, тема, маршрутизатор
+  core/                # модели, API, хранилище, аналитика
+  features/
+    onboarding/
+    library/
+    book_workspace/
+      widgets/chapter_ruler/
+      widgets/editor/
+      widgets/fab_panel/
+    structure_mindmap/
+    ai_composer/
+    voice_training/
+    export/
+    settings/
+  shared/              # дизайн-токены, общие UI-компоненты и утилиты
+```
+
+## Основные технологии
+
+- **Состояние:** Riverpod (`flutter_riverpod`)
+- **Маршрутизация:** `go_router` c поддержкой web `UrlPathStrategy.path`
+- **Редактор:** `flutter_quill`
+- **Аудио:** `record` для записи, `just_audio` для воспроизведения
+- **Структура:** `flutter_treeview`, `drag_and_drop_lists`
+- **Хранилище:** `hive`, `hive_flutter`, `hive_web`
+- **Сеть:** `dio`, `web_socket_channel`
+- **i18n:** `flutter_localizations`
+
+## Запуск
+
+1. Установите зависимости Flutter (3.22+) и запустите `flutter pub get`.
+2. Для web включите `--web-renderer canvaskit` для лучшего отображения стеклянных панелей.
+3. Стартуйте приложение:
+   ```bash
+   flutter run -d chrome
+   ```
+   либо
+   ```bash
+   flutter run -d android
+   ```
+
+## Дальнейшие шаги
+
+- Реализовать загрузку/сохранение данных в Hive и синхронизацию с сервером.
+- Подключить реальные сокеты ASR, API AI Composer и TTS.
+- Заполнить UI состояниями, анимациями и интегрировать горячие клавиши и офлайн-режим PWA.

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,0 +1,14 @@
+include: package:flutter_lints/flutter.yaml
+
+linter:
+  rules:
+    prefer_const_constructors: true
+    prefer_const_literals_to_create_immutables: true
+    always_use_package_imports: true
+    avoid_print: true
+    prefer_single_quotes: true
+
+analyzer:
+  plugins:
+    - riverpod_lint
+

--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'router.dart';
+import 'theme.dart';
+
+class VoicebookApp extends ConsumerWidget {
+  const VoicebookApp({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final router = ref.watch(appRouterProvider);
+    final theme = ref.watch(appThemeProvider);
+
+    return MaterialApp.router(
+      title: 'Voicebook',
+      debugShowCheckedModeBanner: false,
+      theme: theme.lightTheme,
+      darkTheme: theme.darkTheme,
+      themeMode: ref.watch(themeModeProvider),
+      routerConfig: router,
+      supportedLocales: const [
+        Locale('en'),
+        Locale('ru'),
+      ],
+      localizationsDelegates: const [
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+      ],
+    );
+  }
+}

--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../features/ai_composer/ai_composer_drawer.dart';
+import '../features/book_workspace/book_workspace_screen.dart';
+import '../features/export/export_screen.dart';
+import '../features/library/library_screen.dart';
+import '../features/onboarding/onboarding_screen.dart';
+import '../features/settings/settings_screen.dart';
+import '../features/structure_mindmap/structure_mindmap_screen.dart';
+import '../features/voice_training/voice_training_screen.dart';
+
+final appRouterProvider = Provider<GoRouter>((ref) {
+  if (kIsWeb) {
+    GoRouter.setUrlPathStrategy(UrlPathStrategy.path);
+  }
+
+  return GoRouter(
+    initialLocation: '/onboarding',
+    routes: [
+      GoRoute(
+        path: '/onboarding',
+        name: 'onboarding',
+        builder: (context, state) => const OnboardingScreen(),
+      ),
+      GoRoute(
+        path: '/library',
+        name: 'library',
+        builder: (context, state) => const LibraryScreen(),
+      ),
+      GoRoute(
+        path: '/book/:bookId',
+        name: 'book',
+        builder: (context, state) {
+          final bookId = state.pathParameters['bookId']!;
+          return BookWorkspaceScreen(bookId: bookId);
+        },
+        routes: [
+          GoRoute(
+            path: 'structure',
+            name: 'structure',
+            builder: (context, state) {
+              final nodes = state.extra as List? ?? [];
+              return StructureMindmapScreen(nodes: List.from(nodes));
+            },
+          ),
+        ],
+      ),
+      GoRoute(
+        path: '/ai/composer',
+        name: 'aiComposer',
+        pageBuilder: (context, state) {
+          return CustomTransitionPage(
+            key: state.pageKey,
+            child: const AiComposerDrawer(),
+            transitionsBuilder: (context, animation, secondaryAnimation, child) {
+              return SlideTransition(
+                position: Tween<Offset>(begin: const Offset(1, 0), end: Offset.zero).animate(animation),
+                child: child,
+              );
+            },
+          );
+        },
+      ),
+      GoRoute(
+        path: '/voice/training',
+        name: 'voiceTraining',
+        builder: (context, state) => const VoiceTrainingScreen(),
+      ),
+      GoRoute(
+        path: '/export',
+        name: 'export',
+        builder: (context, state) {
+          final bookId = state.uri.queryParameters['bookId'] ?? '';
+          return ExportScreen(bookId: bookId);
+        },
+      ),
+      GoRoute(
+        path: '/settings',
+        name: 'settings',
+        builder: (context, state) => const SettingsScreen(),
+      ),
+    ],
+  );
+});

--- a/lib/app/theme.dart
+++ b/lib/app/theme.dart
@@ -1,0 +1,86 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../shared/tokens/design_tokens.dart';
+
+final themeModeProvider = StateProvider<ThemeMode>((ref) => ThemeMode.system);
+
+final appThemeProvider = Provider<AppTheme>((ref) => const AppTheme());
+
+class AppTheme {
+  const AppTheme();
+
+  ThemeData get lightTheme {
+    final base = ThemeData.light(useMaterial3: true);
+    return base.copyWith(
+      colorScheme: ColorScheme.fromSeed(
+        seedColor: AppColors.primary,
+        primary: AppColors.primary,
+        secondary: AppColors.secondary,
+        surfaceTint: AppColors.primary,
+        error: AppColors.error,
+      ),
+      scaffoldBackgroundColor: Colors.white,
+      appBarTheme: const AppBarTheme(
+        backgroundColor: Colors.transparent,
+        elevation: 0,
+        surfaceTintColor: Colors.transparent,
+      ),
+      textTheme: AppTypography.textTheme,
+      chipTheme: base.chipTheme.copyWith(
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(AppSpacing.radiusMedium),
+        ),
+      ),
+      inputDecorationTheme: InputDecorationTheme(
+        border: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(AppSpacing.radiusSmall),
+          borderSide: const BorderSide(color: AppColors.border),
+        ),
+        focusedBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(AppSpacing.radiusSmall),
+          borderSide: const BorderSide(color: AppColors.primary, width: 1.4),
+        ),
+      ),
+      floatingActionButtonTheme: const FloatingActionButtonThemeData(
+        shape: StadiumBorder(),
+      ),
+    );
+  }
+
+  ThemeData get darkTheme {
+    final base = ThemeData.dark(useMaterial3: true);
+    return base.copyWith(
+      colorScheme: ColorScheme.fromSeed(
+        brightness: Brightness.dark,
+        seedColor: AppColors.primary,
+        primary: AppColors.primary,
+        secondary: AppColors.secondary,
+        surface: AppColors.darkSurface,
+        error: AppColors.error,
+      ),
+      scaffoldBackgroundColor: AppColors.darkSurface,
+      appBarTheme: const AppBarTheme(
+        backgroundColor: Colors.transparent,
+        elevation: 0,
+        surfaceTintColor: Colors.transparent,
+      ),
+      textTheme: AppTypography.textTheme.apply(bodyColor: Colors.white),
+      chipTheme: base.chipTheme.copyWith(
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(AppSpacing.radiusMedium),
+        ),
+      ),
+      inputDecorationTheme: InputDecorationTheme(
+        border: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(AppSpacing.radiusSmall),
+          borderSide: const BorderSide(color: AppColors.darkBorder),
+        ),
+        focusedBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(AppSpacing.radiusSmall),
+          borderSide: const BorderSide(color: AppColors.primary, width: 1.4),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/core/analytics/analytics_service.dart
+++ b/lib/core/analytics/analytics_service.dart
@@ -1,0 +1,13 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'events.dart';
+
+final analyticsServiceProvider = Provider<AnalyticsService>((ref) {
+  return AnalyticsService();
+});
+
+class AnalyticsService {
+  Future<void> log(AnalyticsEvent event, [Map<String, Object?>? params]) async {
+    // TODO: integrate with analytics backend.
+  }
+}

--- a/lib/core/analytics/events.dart
+++ b/lib/core/analytics/events.dart
@@ -1,0 +1,13 @@
+enum AnalyticsEvent {
+  bookCreated('book_created'),
+  chapterCreated('chapter_created'),
+  asrStarted('asr_started'),
+  asrStopped('asr_stopped'),
+  aiComposeApplied('ai_compose_applied'),
+  ttsPreviewed('tts_previewed'),
+  exportDone('export_done');
+
+  const AnalyticsEvent(this.key);
+
+  final String key;
+}

--- a/lib/core/api/api_client.dart
+++ b/lib/core/api/api_client.dart
@@ -1,0 +1,12 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+final apiClientProvider = Provider<Dio>((ref) {
+  return Dio(
+    BaseOptions(
+      baseUrl: 'https://api.example.com',
+      connectTimeout: const Duration(seconds: 20),
+      receiveTimeout: const Duration(seconds: 30),
+    ),
+  );
+});

--- a/lib/core/models/asr_session.dart
+++ b/lib/core/models/asr_session.dart
@@ -1,0 +1,22 @@
+import 'package:equatable/equatable.dart';
+
+import 'ids.dart';
+
+enum AsrMode { live, batch }
+
+class AsrSession extends Equatable {
+  const AsrSession({
+    required this.id,
+    required this.lang,
+    required this.mode,
+    required this.startedAt,
+  });
+
+  final ID id;
+  final String lang;
+  final AsrMode mode;
+  final DateTime startedAt;
+
+  @override
+  List<Object?> get props => [id, lang, mode, startedAt];
+}

--- a/lib/core/models/chapter.dart
+++ b/lib/core/models/chapter.dart
@@ -1,0 +1,63 @@
+import 'package:equatable/equatable.dart';
+
+import 'ids.dart';
+import 'rich_block.dart';
+import 'scene_node.dart';
+
+enum ChapterStatus { draft, edit, final_ }
+
+enum RichBlockType { paragraph, h1, h2, bullet, quote, code }
+
+class Chapter extends Equatable {
+  const Chapter({
+    required this.id,
+    required this.bookId,
+    required this.title,
+    this.subtitle,
+    this.status = ChapterStatus.draft,
+    this.meta = const {},
+    this.structure = const [],
+    this.blocks = const [],
+  });
+
+  final ID id;
+  final ID bookId;
+  final String title;
+  final String? subtitle;
+  final ChapterStatus status;
+  final Map<String, String?> meta;
+  final List<SceneNode> structure;
+  final List<RichBlock> blocks;
+
+  Chapter copyWith({
+    String? title,
+    String? subtitle,
+    ChapterStatus? status,
+    Map<String, String?>? meta,
+    List<SceneNode>? structure,
+    List<RichBlock>? blocks,
+  }) {
+    return Chapter(
+      id: id,
+      bookId: bookId,
+      title: title ?? this.title,
+      subtitle: subtitle ?? this.subtitle,
+      status: status ?? this.status,
+      meta: meta ?? this.meta,
+      structure: structure ?? this.structure,
+      blocks: blocks ?? this.blocks,
+    );
+  }
+
+  @override
+  List<Object?> get props => [
+        id,
+        bookId,
+        title,
+        subtitle,
+        status,
+        meta,
+        structure,
+        blocks,
+      ];
+}

--- a/lib/core/models/chapter_summary.dart
+++ b/lib/core/models/chapter_summary.dart
@@ -1,0 +1,33 @@
+import 'package:equatable/equatable.dart';
+
+import 'ids.dart';
+
+class ChapterSummary extends Equatable {
+  const ChapterSummary({
+    required this.id,
+    required this.title,
+    required this.order,
+    required this.wordCount,
+  });
+
+  final ID id;
+  final String title;
+  final int order;
+  final int wordCount;
+
+  ChapterSummary copyWith({
+    String? title,
+    int? order,
+    int? wordCount,
+  }) {
+    return ChapterSummary(
+      id: id,
+      title: title ?? this.title,
+      order: order ?? this.order,
+      wordCount: wordCount ?? this.wordCount,
+    );
+  }
+
+  @override
+  List<Object?> get props => [id, title, order, wordCount];
+}

--- a/lib/core/models/ids.dart
+++ b/lib/core/models/ids.dart
@@ -1,0 +1,1 @@
+typedef ID = String;

--- a/lib/core/models/models.dart
+++ b/lib/core/models/models.dart
@@ -1,0 +1,8 @@
+export 'asr_session.dart';
+export 'chapter.dart';
+export 'chapter_summary.dart';
+export 'ids.dart';
+export 'notebook.dart';
+export 'rich_block.dart';
+export 'scene_node.dart';
+export 'voice_profile.dart';

--- a/lib/core/models/notebook.dart
+++ b/lib/core/models/notebook.dart
@@ -1,0 +1,58 @@
+import 'package:equatable/equatable.dart';
+
+import 'ids.dart';
+
+class Notebook extends Equatable {
+  const Notebook({
+    required this.id,
+    required this.title,
+    this.coverUrl,
+    this.tags = const [],
+    required this.updatedAt,
+    this.chapters = 0,
+    this.words = 0,
+    this.audioMinutes = 0,
+  });
+
+  final ID id;
+  final String title;
+  final String? coverUrl;
+  final List<String> tags;
+  final DateTime updatedAt;
+  final int chapters;
+  final int words;
+  final double audioMinutes;
+
+  Notebook copyWith({
+    String? title,
+    String? coverUrl,
+    List<String>? tags,
+    DateTime? updatedAt,
+    int? chapters,
+    int? words,
+    double? audioMinutes,
+  }) {
+    return Notebook(
+      id: id,
+      title: title ?? this.title,
+      coverUrl: coverUrl ?? this.coverUrl,
+      tags: tags ?? this.tags,
+      updatedAt: updatedAt ?? this.updatedAt,
+      chapters: chapters ?? this.chapters,
+      words: words ?? this.words,
+      audioMinutes: audioMinutes ?? this.audioMinutes,
+    );
+  }
+
+  @override
+  List<Object?> get props => [
+        id,
+        title,
+        coverUrl,
+        tags,
+        updatedAt,
+        chapters,
+        words,
+        audioMinutes,
+      ];
+}

--- a/lib/core/models/rich_block.dart
+++ b/lib/core/models/rich_block.dart
@@ -1,0 +1,34 @@
+import 'package:equatable/equatable.dart';
+
+import 'chapter.dart';
+import 'ids.dart';
+
+class RichBlock extends Equatable {
+  const RichBlock({
+    required this.id,
+    required this.type,
+    required this.text,
+    this.marks = const [],
+  });
+
+  final ID id;
+  final RichBlockType type;
+  final String text;
+  final List<String> marks;
+
+  RichBlock copyWith({
+    RichBlockType? type,
+    String? text,
+    List<String>? marks,
+  }) {
+    return RichBlock(
+      id: id,
+      type: type ?? this.type,
+      text: text ?? this.text,
+      marks: marks ?? this.marks,
+    );
+  }
+
+  @override
+  List<Object?> get props => [id, type, text, marks];
+}

--- a/lib/core/models/scene_node.dart
+++ b/lib/core/models/scene_node.dart
@@ -1,0 +1,29 @@
+import 'package:equatable/equatable.dart';
+
+import 'ids.dart';
+
+class SceneNode extends Equatable {
+  const SceneNode({
+    required this.id,
+    required this.title,
+    this.children = const [],
+  });
+
+  final ID id;
+  final String title;
+  final List<SceneNode> children;
+
+  SceneNode copyWith({
+    String? title,
+    List<SceneNode>? children,
+  }) {
+    return SceneNode(
+      id: id,
+      title: title ?? this.title,
+      children: children ?? this.children,
+    );
+  }
+
+  @override
+  List<Object?> get props => [id, title, children];
+}

--- a/lib/core/models/voice_profile.dart
+++ b/lib/core/models/voice_profile.dart
@@ -1,0 +1,43 @@
+import 'package:equatable/equatable.dart';
+
+import 'ids.dart';
+
+enum VoiceProfileStatus { training, ready, failed }
+
+class VoiceProfile extends Equatable {
+  const VoiceProfile({
+    required this.id,
+    required this.name,
+    required this.kind,
+    required this.locale,
+    required this.status,
+    this.isConsentGiven = false,
+  });
+
+  final ID id;
+  final String name;
+  final String kind;
+  final String locale;
+  final VoiceProfileStatus status;
+  final bool isConsentGiven;
+
+  VoiceProfile copyWith({
+    String? name,
+    String? kind,
+    String? locale,
+    VoiceProfileStatus? status,
+    bool? isConsentGiven,
+  }) {
+    return VoiceProfile(
+      id: id,
+      name: name ?? this.name,
+      kind: kind ?? this.kind,
+      locale: locale ?? this.locale,
+      status: status ?? this.status,
+      isConsentGiven: isConsentGiven ?? this.isConsentGiven,
+    );
+  }
+
+  @override
+  List<Object?> get props => [id, name, kind, locale, status, isConsentGiven];
+}

--- a/lib/core/storage/storage_service.dart
+++ b/lib/core/storage/storage_service.dart
@@ -1,0 +1,23 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:hive/hive.dart';
+
+import '../models/models.dart';
+
+final storageServiceProvider = Provider<StorageService>((ref) {
+  return StorageService();
+});
+
+class StorageService {
+  Future<void> init() async {
+    // TODO: initialize Hive for mobile/web.
+  }
+
+  Future<List<Notebook>> loadNotebooks() async {
+    // TODO: load from Hive boxes.
+    return const [];
+  }
+
+  Future<void> saveNotebook(Notebook notebook) async {
+    // TODO: persist notebook.
+  }
+}

--- a/lib/features/ai_composer/ai_composer_drawer.dart
+++ b/lib/features/ai_composer/ai_composer_drawer.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+
+class AiComposerDrawer extends StatelessWidget {
+  const AiComposerDrawer({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Drawer(
+      child: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text('AI Composer', style: Theme.of(context).textTheme.headlineMedium),
+              const SizedBox(height: 16),
+              const Text('Выберите действие, чтобы улучшить текст.'),
+              const SizedBox(height: 24),
+              Wrap(
+                spacing: 12,
+                runSpacing: 12,
+                children: [
+                  _PresetChip(label: 'Художественный'),
+                  _PresetChip(label: 'Научно-популярный'),
+                  _PresetChip(label: 'Эссе'),
+                  _PresetChip(label: 'Диалог'),
+                ],
+              ),
+              const SizedBox(height: 24),
+              FilledButton.icon(
+                onPressed: () {},
+                icon: const Icon(Icons.auto_awesome),
+                label: const Text('Расширить'),
+              ),
+              const SizedBox(height: 12),
+              FilledButton.icon(
+                onPressed: () {},
+                icon: const Icon(Icons.swap_calls),
+                label: const Text('Перефразировать'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _PresetChip extends StatelessWidget {
+  const _PresetChip({required this.label});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return FilterChip(label: Text(label), selected: true, onSelected: (_) {});
+  }
+}

--- a/lib/features/book_workspace/book_workspace_screen.dart
+++ b/lib/features/book_workspace/book_workspace_screen.dart
@@ -1,0 +1,96 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../core/models/models.dart';
+import '../../shared/tokens/design_tokens.dart';
+import 'widgets/chapter_ruler/chapter_ruler.dart';
+import 'widgets/editor/chapter_editor.dart';
+import 'widgets/fab_panel/fab_action_cluster.dart';
+
+final currentChapterProvider = StateProvider<Chapter?>((ref) => null);
+
+class BookWorkspaceScreen extends ConsumerWidget {
+  const BookWorkspaceScreen({super.key, required this.bookId});
+
+  final String bookId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final chapter = ref.watch(currentChapterProvider);
+
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final isDesktop = constraints.maxWidth >= 1024;
+        final isTablet = constraints.maxWidth >= 600 && constraints.maxWidth < 1024;
+
+        final ruler = SizedBox(
+          width: isDesktop ? 88 : 64,
+          child: ChapterRuler(
+            chapters: const [],
+            onSelect: (_) {},
+            onAdd: () {},
+            onReorder: (oldIndex, newIndex) {},
+          ),
+        );
+
+        final editor = Expanded(
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: AppSpacing.gutter),
+            child: ChapterEditor(chapter: chapter),
+          ),
+        );
+
+        final fabPanel = Align(
+          alignment: Alignment.bottomRight,
+          child: Padding(
+            padding: const EdgeInsets.all(AppSpacing.outer),
+            child: FabActionCluster(
+              onStartStop: () {},
+              onOpenComposer: () {},
+              onPreviewTts: () {},
+            ),
+          ),
+        );
+
+        if (isDesktop) {
+          return Scaffold(
+            body: SafeArea(
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  ruler,
+                  editor,
+                  Expanded(
+                    child: Stack(
+                      children: [
+                        Container(),
+                        fabPanel,
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          );
+        }
+
+        return Scaffold(
+          body: SafeArea(
+            child: Column(
+              children: [
+                SizedBox(height: isTablet ? 88 : 72, child: ruler),
+                Expanded(child: editor),
+              ],
+            ),
+          ),
+          floatingActionButtonLocation: FloatingActionButtonLocation.endFloat,
+          floatingActionButton: FabActionCluster(
+            onStartStop: () {},
+            onOpenComposer: () {},
+            onPreviewTts: () {},
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/features/book_workspace/widgets/chapter_ruler/chapter_ruler.dart
+++ b/lib/features/book_workspace/widgets/chapter_ruler/chapter_ruler.dart
@@ -1,0 +1,99 @@
+import 'package:flutter/material.dart';
+
+import '../../../../core/models/models.dart';
+import '../../../../shared/tokens/design_tokens.dart';
+
+class ChapterRuler extends StatelessWidget {
+  const ChapterRuler({
+    super.key,
+    required this.chapters,
+    required this.onSelect,
+    required this.onAdd,
+    required this.onReorder,
+  });
+
+  final List<ChapterSummary> chapters;
+  final ValueChanged<String> onSelect;
+  final VoidCallback onAdd;
+  final void Function(int from, int to) onReorder;
+
+  @override
+  Widget build(BuildContext context) {
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        gradient: const LinearGradient(
+          colors: [AppColors.primary, AppColors.secondary],
+          begin: Alignment.topCenter,
+          end: Alignment.bottomCenter,
+        ),
+        borderRadius: BorderRadius.circular(AppSpacing.radiusLarge),
+      ),
+      child: Column(
+        children: [
+          Expanded(
+            child: ListView.separated(
+              padding: const EdgeInsets.symmetric(vertical: 24),
+              itemCount: chapters.length,
+              separatorBuilder: (_, __) => const SizedBox(height: 12),
+              itemBuilder: (context, index) {
+                final chapter = chapters[index];
+                return _ChapterPill(
+                  title: chapter.title,
+                  index: index + 1,
+                  onTap: () => onSelect(chapter.id),
+                );
+              },
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.all(12),
+            child: OutlinedButton.icon(
+              style: OutlinedButton.styleFrom(
+                foregroundColor: Colors.white,
+                side: const BorderSide(color: Colors.white70),
+              ),
+              onPressed: onAdd,
+              icon: const Icon(Icons.add),
+              label: const Text('Глава'),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ChapterPill extends StatelessWidget {
+  const _ChapterPill({required this.title, required this.index, required this.onTap});
+
+  final String title;
+  final int index;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 12),
+      child: InkWell(
+        borderRadius: BorderRadius.circular(AppSpacing.radiusLarge),
+        onTap: onTap,
+        child: Ink(
+          padding: const EdgeInsets.symmetric(vertical: 12, horizontal: 16),
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(AppSpacing.radiusLarge),
+            color: Colors.white.withOpacity(0.2),
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text('Глава $index', style: theme.textTheme.labelMedium?.copyWith(color: Colors.white70)),
+              const SizedBox(height: 4),
+              Text(title, style: theme.textTheme.titleMedium?.copyWith(color: Colors.white)),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/book_workspace/widgets/editor/chapter_editor.dart
+++ b/lib/features/book_workspace/widgets/editor/chapter_editor.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_quill/flutter_quill.dart' as quill;
+
+import '../../../../core/models/models.dart';
+import '../../../../shared/ui/glass_card.dart';
+
+class ChapterEditor extends StatefulWidget {
+  const ChapterEditor({super.key, required this.chapter});
+
+  final Chapter? chapter;
+
+  @override
+  State<ChapterEditor> createState() => _ChapterEditorState();
+}
+
+class _ChapterEditorState extends State<ChapterEditor> {
+  late final quill.QuillController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = quill.QuillController.basic();
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final chapter = widget.chapter;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Text(chapter?.title ?? 'Без названия', style: Theme.of(context).textTheme.headlineMedium),
+        const SizedBox(height: 12),
+        Expanded(
+          child: GlassCard(
+            child: quill.QuillEditor.basic(
+              controller: _controller,
+              configurations: const quill.QuillEditorConfigurations(
+                scrollable: true,
+                expands: true,
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/book_workspace/widgets/fab_panel/fab_action_cluster.dart
+++ b/lib/features/book_workspace/widgets/fab_panel/fab_action_cluster.dart
@@ -1,0 +1,77 @@
+import 'package:flutter/material.dart';
+
+import '../../../../shared/tokens/design_tokens.dart';
+
+class FabActionCluster extends StatelessWidget {
+  const FabActionCluster({
+    super.key,
+    required this.onStartStop,
+    required this.onOpenComposer,
+    required this.onPreviewTts,
+  });
+
+  final VoidCallback onStartStop;
+  final VoidCallback onOpenComposer;
+  final VoidCallback onPreviewTts;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.end,
+      children: [
+        _ActionButton(
+          icon: Icons.auto_fix_high,
+          label: 'Сформировать текст',
+          onPressed: onOpenComposer,
+        ),
+        const SizedBox(height: 12),
+        _ActionButton(
+          icon: Icons.spatial_audio,
+          label: 'Озвучить',
+          onPressed: onPreviewTts,
+        ),
+        const SizedBox(height: 16),
+        MicRecordButton(onPressed: onStartStop),
+      ],
+    );
+  }
+}
+
+class MicRecordButton extends StatelessWidget {
+  const MicRecordButton({super.key, required this.onPressed});
+
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return ElevatedButton(
+      style: ElevatedButton.styleFrom(
+        shape: const CircleBorder(),
+        padding: const EdgeInsets.all(20),
+        backgroundColor: AppColors.error,
+        foregroundColor: Colors.white,
+        elevation: 6,
+      ),
+      onPressed: onPressed,
+      child: const Icon(Icons.mic, size: 32),
+    );
+  }
+}
+
+class _ActionButton extends StatelessWidget {
+  const _ActionButton({required this.icon, required this.label, required this.onPressed});
+
+  final IconData icon;
+  final String label;
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return FilledButton.icon(
+      onPressed: onPressed,
+      icon: Icon(icon),
+      label: Text(label),
+    );
+  }
+}

--- a/lib/features/export/export_screen.dart
+++ b/lib/features/export/export_screen.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+
+import '../../shared/ui/glass_card.dart';
+
+class ExportScreen extends StatelessWidget {
+  const ExportScreen({super.key, required this.bookId});
+
+  final String bookId;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Экспорт')),
+      body: Padding(
+        padding: const EdgeInsets.all(24),
+        child: GlassCard(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text('Экспорт книги', style: Theme.of(context).textTheme.headlineMedium),
+              const SizedBox(height: 16),
+              const Text('Выберите формат для текста и аудио.'),
+              const SizedBox(height: 24),
+              Wrap(
+                spacing: 12,
+                children: const [
+                  ChoiceChip(label: Text('Markdown'), selected: true),
+                  ChoiceChip(label: Text('DOCX'), selected: false),
+                  ChoiceChip(label: Text('EPUB'), selected: false),
+                ],
+              ),
+              const SizedBox(height: 24),
+              FilledButton.icon(
+                onPressed: () {},
+                icon: const Icon(Icons.download),
+                label: const Text('Экспортировать'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/library/library_screen.dart
+++ b/lib/features/library/library_screen.dart
@@ -1,0 +1,67 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../core/models/models.dart';
+import '../../shared/tokens/design_tokens.dart';
+import '../../shared/ui/glass_app_bar.dart';
+import '../../shared/ui/glass_card.dart';
+import '../../shared/ui/primary_button.dart';
+import 'widgets/notebook_card.dart';
+
+final notebooksProvider = StateProvider<List<Notebook>>((ref) => const []);
+
+class LibraryScreen extends ConsumerWidget {
+  const LibraryScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final notebooks = ref.watch(notebooksProvider);
+
+    return Scaffold(
+      appBar: GlassAppBar(
+        title: 'Библиотека',
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.search),
+            onPressed: () {},
+          ),
+        ],
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(AppSpacing.outer),
+        child: notebooks.isEmpty
+            ? Center(
+                child: GlassCard(
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Text('Создайте свою первую книгу',
+                          style: Theme.of(context).textTheme.headlineMedium),
+                      const SizedBox(height: 16),
+                      const PrimaryButton(label: 'Новая книга', onPressed: null, icon: Icons.add),
+                    ],
+                  ),
+                ),
+              )
+            : GridView.builder(
+                itemCount: notebooks.length,
+                gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+                  crossAxisCount: 3,
+                  crossAxisSpacing: AppSpacing.gutter,
+                  mainAxisSpacing: AppSpacing.gutter,
+                  childAspectRatio: 0.72,
+                ),
+                itemBuilder: (context, index) {
+                  final notebook = notebooks[index];
+                  return NotebookCard(notebook: notebook);
+                },
+              ),
+      ),
+      floatingActionButton: FloatingActionButton.extended(
+        onPressed: () {},
+        icon: const Icon(Icons.add),
+        label: const Text('Новая книга'),
+      ),
+    );
+  }
+}

--- a/lib/features/library/widgets/notebook_card.dart
+++ b/lib/features/library/widgets/notebook_card.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+
+import '../../../core/models/notebook.dart';
+import '../../../shared/tokens/design_tokens.dart';
+
+class NotebookCard extends StatelessWidget {
+  const NotebookCard({super.key, required this.notebook});
+
+  final Notebook notebook;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return InkWell(
+      borderRadius: BorderRadius.circular(AppSpacing.radiusMedium),
+      onTap: () {
+        // TODO: open notebook.
+      },
+      child: Ink(
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(AppSpacing.radiusMedium),
+          gradient: const LinearGradient(
+            colors: [AppColors.primary, AppColors.secondary],
+            begin: Alignment.topLeft,
+            end: Alignment.bottomRight,
+          ),
+        ),
+        child: Padding(
+          padding: const EdgeInsets.all(20),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Expanded(
+                child: Align(
+                  alignment: Alignment.topRight,
+                  child: Text(
+                    '${notebook.chapters} глав',
+                    style: theme.textTheme.labelMedium!.copyWith(color: Colors.white70),
+                  ),
+                ),
+              ),
+              Text(
+                notebook.title,
+                style: theme.textTheme.titleLarge!.copyWith(color: Colors.white),
+                maxLines: 2,
+              ),
+              const SizedBox(height: 12),
+              Text(
+                'Обновлено ${notebook.updatedAt}',
+                style: theme.textTheme.bodySmall?.copyWith(color: Colors.white70),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/onboarding/onboarding_screen.dart
+++ b/lib/features/onboarding/onboarding_screen.dart
@@ -1,0 +1,83 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../shared/ui/glass_app_bar.dart';
+import '../../shared/ui/primary_button.dart';
+
+class OnboardingScreen extends ConsumerWidget {
+  const OnboardingScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Scaffold(
+      extendBodyBehindAppBar: true,
+      appBar: const GlassAppBar(title: 'Voicebook'),
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Expanded(
+                child: PageView(
+                  children: const [
+                    _BenefitCard(
+                      title: 'Диктуйте, редактируйте, экспортируйте',
+                      description:
+                          'Voicebook объединяет запись, AI-редактуру и озвучку в одном пространстве.',
+                    ),
+                    _BenefitCard(
+                      title: 'Работает офлайн',
+                      description:
+                          'Последние главы доступны без сети, а прогресс синхронизируется позже.',
+                    ),
+                    _BenefitCard(
+                      title: 'Ваша студия звучания',
+                      description:
+                          'Тренируйте персональный голос и создавайте аудиокниги в один клик.',
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(height: 32),
+              PrimaryButton(
+                label: 'Начать диктовку',
+                onPressed: () {
+                  // Permissions and navigation handled in controller.
+                },
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _BenefitCard extends StatelessWidget {
+  const _BenefitCard({required this.title, required this.description});
+
+  final String title;
+  final String description;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Card(
+      elevation: 0,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(24)),
+      child: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Text(title, style: theme.textTheme.headlineLarge),
+            const SizedBox(height: 16),
+            Text(description, style: theme.textTheme.bodyLarge),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/settings/settings_screen.dart
+++ b/lib/features/settings/settings_screen.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+class SettingsScreen extends ConsumerWidget {
+  const SettingsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Настройки')),
+      body: ListView(
+        padding: const EdgeInsets.all(24),
+        children: [
+          Text('Распознавание речи', style: Theme.of(context).textTheme.titleLarge),
+          SwitchListTile(
+            value: true,
+            onChanged: (_) {},
+            title: const Text('Автопунктуация'),
+          ),
+          const SizedBox(height: 24),
+          Text('AI Composer', style: Theme.of(context).textTheme.titleLarge),
+          ListTile(
+            title: const Text('Провайдер'),
+            subtitle: const Text('Default'),
+            trailing: const Icon(Icons.chevron_right),
+            onTap: () {},
+          ),
+          const SizedBox(height: 24),
+          Text('Озвучка', style: Theme.of(context).textTheme.titleLarge),
+          ListTile(
+            title: const Text('Голос по умолчанию'),
+            trailing: const Icon(Icons.chevron_right),
+            onTap: () {},
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/structure_mindmap/structure_mindmap_screen.dart
+++ b/lib/features/structure_mindmap/structure_mindmap_screen.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_treeview/flutter_treeview.dart';
+
+import '../../core/models/models.dart';
+import '../../shared/ui/glass_card.dart';
+
+class StructureMindmapScreen extends StatelessWidget {
+  const StructureMindmapScreen({super.key, required this.nodes});
+
+  final List<SceneNode> nodes;
+
+  @override
+  Widget build(BuildContext context) {
+    return Dialog(
+      insetPadding: const EdgeInsets.all(32),
+      child: GlassCard(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text('Структура главы', style: Theme.of(context).textTheme.headlineMedium),
+            const SizedBox(height: 16),
+            Expanded(
+              child: TreeView(
+                shrinkWrap: true,
+                controller: TreeViewController(
+                  children: nodes
+                      .map(
+                        (node) => Node(
+                          label: node.title,
+                          key: node.id,
+                          children: node.children
+                              .map((child) => Node(label: child.title, key: child.id))
+                              .toList(),
+                        ),
+                      )
+                      .toList(),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/voice_training/voice_training_screen.dart
+++ b/lib/features/voice_training/voice_training_screen.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../shared/ui/glass_card.dart';
+
+class VoiceTrainingScreen extends ConsumerWidget {
+  const VoiceTrainingScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Тренировка голоса')),
+      body: Padding(
+        padding: const EdgeInsets.all(24),
+        child: GlassCard(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text('Запишите несколько фраз', style: Theme.of(context).textTheme.headlineMedium),
+              const SizedBox(height: 16),
+              const Text('Озвучка станет доступна после завершения анализа качества.'),
+              const SizedBox(height: 24),
+              FilledButton.icon(
+                onPressed: () {},
+                icon: const Icon(Icons.mic),
+                label: const Text('Записать фразу'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'app/app.dart';
+
+void main() {
+  WidgetsFlutterBinding.ensureInitialized();
+  runApp(const ProviderScope(child: VoicebookApp()));
+}

--- a/lib/shared/tokens/design_tokens.dart
+++ b/lib/shared/tokens/design_tokens.dart
@@ -1,0 +1,73 @@
+import 'package:flutter/material.dart';
+
+class AppColors {
+  AppColors._();
+
+  static const primary = Color(0xFF6366F1);
+  static const secondary = Color(0xFF8B5CF6);
+  static const accent = Color(0xFF06B6D4);
+  static const error = Color(0xFFDF3F40);
+  static const border = Color(0xFFE3E6EA);
+
+  static const darkSurface = Color(0xFF0B0D12);
+  static const darkBorder = Color(0x22FFFFFF);
+}
+
+class AppSpacing {
+  AppSpacing._();
+
+  static const outer = 20.0;
+  static const gutter = 16.0;
+  static const radiusSmall = 6.0;
+  static const radiusMedium = 16.0;
+  static const radiusLarge = 24.0;
+}
+
+class AppTypography {
+  AppTypography._();
+
+  static const fontFamily = 'Inter';
+
+  static TextTheme textTheme = const TextTheme(
+    displayMedium: TextStyle(
+      fontFamily: fontFamily,
+      fontWeight: FontWeight.w500,
+      fontSize: 32,
+    ),
+    headlineLarge: TextStyle(
+      fontFamily: fontFamily,
+      fontWeight: FontWeight.w500,
+      fontSize: 28,
+    ),
+    headlineMedium: TextStyle(
+      fontFamily: fontFamily,
+      fontWeight: FontWeight.w500,
+      fontSize: 24,
+    ),
+    headlineSmall: TextStyle(
+      fontFamily: fontFamily,
+      fontWeight: FontWeight.w500,
+      fontSize: 20,
+    ),
+    titleLarge: TextStyle(
+      fontFamily: fontFamily,
+      fontWeight: FontWeight.w500,
+      fontSize: 18,
+    ),
+    bodyLarge: TextStyle(
+      fontFamily: fontFamily,
+      fontWeight: FontWeight.w400,
+      fontSize: 16,
+    ),
+    bodyMedium: TextStyle(
+      fontFamily: fontFamily,
+      fontWeight: FontWeight.w400,
+      fontSize: 14,
+    ),
+    labelMedium: TextStyle(
+      fontFamily: fontFamily,
+      fontWeight: FontWeight.w500,
+      fontSize: 13,
+    ),
+  );
+}

--- a/lib/shared/ui/glass_app_bar.dart
+++ b/lib/shared/ui/glass_app_bar.dart
@@ -1,0 +1,29 @@
+import 'dart:ui';
+
+import 'package:flutter/material.dart';
+
+class GlassAppBar extends StatelessWidget implements PreferredSizeWidget {
+  const GlassAppBar({super.key, this.title, this.actions});
+
+  final String? title;
+  final List<Widget>? actions;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return ClipRRect(
+      child: BackdropFilter(
+        filter: ImageFilter.blur(sigmaX: 16, sigmaY: 16),
+        child: AppBar(
+          title: title != null ? Text(title!, style: theme.textTheme.titleLarge) : null,
+          actions: actions,
+          backgroundColor: theme.colorScheme.surface.withOpacity(0.85),
+          elevation: 0,
+        ),
+      ),
+    );
+  }
+
+  @override
+  Size get preferredSize => const Size.fromHeight(kToolbarHeight);
+}

--- a/lib/shared/ui/glass_card.dart
+++ b/lib/shared/ui/glass_card.dart
@@ -1,0 +1,32 @@
+import 'dart:ui';
+
+import 'package:flutter/material.dart';
+
+import '../tokens/design_tokens.dart';
+
+class GlassCard extends StatelessWidget {
+  const GlassCard({super.key, required this.child, this.padding = const EdgeInsets.all(24)});
+
+  final Widget child;
+  final EdgeInsetsGeometry padding;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(AppSpacing.radiusMedium),
+      child: BackdropFilter(
+        filter: ImageFilter.blur(sigmaX: 12, sigmaY: 12),
+        child: Container(
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(AppSpacing.radiusMedium),
+            border: Border.all(color: theme.colorScheme.outlineVariant.withOpacity(0.4)),
+            color: theme.colorScheme.surface.withOpacity(0.75),
+          ),
+          padding: padding,
+          child: child,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/shared/ui/primary_button.dart
+++ b/lib/shared/ui/primary_button.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart';
+
+import '../tokens/design_tokens.dart';
+
+class PrimaryButton extends StatelessWidget {
+  const PrimaryButton({super.key, required this.label, required this.onPressed, this.icon});
+
+  final String label;
+  final VoidCallback? onPressed;
+  final IconData? icon;
+
+  @override
+  Widget build(BuildContext context) {
+    return ElevatedButton.icon(
+      style: ElevatedButton.styleFrom(
+        padding: const EdgeInsets.symmetric(vertical: 16, horizontal: 24),
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(AppSpacing.radiusLarge)),
+        backgroundColor: AppColors.primary,
+        foregroundColor: Colors.white,
+      ),
+      onPressed: onPressed,
+      icon: Icon(icon ?? Icons.mic_rounded),
+      label: Text(label),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,0 +1,46 @@
+name: voicebook
+description: Voice-first book editor for Android and Web built with Flutter.
+publish_to: 'none'
+version: 0.1.0+1
+
+environment:
+  sdk: '>=3.3.0 <4.0.0'
+  flutter: '>=3.22.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+  flutter_localizations:
+    sdk: flutter
+  go_router: ^14.1.4
+  flutter_riverpod: ^2.5.1
+  dio: ^5.4.2+1
+  web_socket_channel: ^3.0.1
+  flutter_quill: ^9.3.5
+  record: ^5.0.5
+  just_audio: ^0.9.36
+  flutter_treeview: ^1.0.7
+  drag_and_drop_lists: ^0.3.6
+  reorderables: ^0.6.0
+  hive: ^2.2.3
+  hive_flutter: ^1.1.0
+  hive_web: ^1.1.0
+  intl: ^0.19.0
+  equatable: ^2.0.5
+  freezed_annotation: ^2.4.1
+  json_annotation: ^4.9.0
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  flutter_lints: ^3.0.1
+  build_runner: ^2.4.9
+  freezed: ^2.5.2
+  json_serializable: ^6.7.1
+  riverpod_lint: ^2.3.7
+
+flutter:
+  uses-material-design: true
+  assets:
+    - assets/illustrations/
+    - assets/icons/


### PR DESCRIPTION
## Summary
- scaffold a Flutter 3.22+ project targeting Android and Web with Riverpod state management and go_router navigation
- define domain models, analytics events, and service placeholders for storage, API, and audio/AI integrations
- add feature shells for onboarding, library, book workspace, AI composer, voice training, export, and settings with reusable glassmorphism UI kit

## Testing
- not run (Flutter SDK unavailable in container)


------
https://chatgpt.com/codex/tasks/task_b_68d6f6bd80bc8322882c0b6bdf8c8168