### PR TITLE
Fix Flutter 3.22 compatibility issues

### DIFF
--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_web_plugins/url_strategy.dart';
 import 'package:go_router/go_router.dart';
 
 import '../features/ai_composer/ai_composer_drawer.dart';
@@ -14,7 +15,7 @@ import '../features/voice_training/voice_training_screen.dart';
 
 final appRouterProvider = Provider<GoRouter>((ref) {
   if (kIsWeb) {
-    GoRouter.setUrlPathStrategy(UrlPathStrategy.path);
+    setUrlStrategy(PathUrlStrategy());
   }
 
   return GoRouter(

--- a/lib/features/book_workspace/widgets/editor/chapter_editor.dart
+++ b/lib/features/book_workspace/widgets/editor/chapter_editor.dart
@@ -40,7 +40,7 @@ class _ChapterEditorState extends State<ChapterEditor> {
           child: GlassCard(
             child: quill.QuillEditor.basic(
               controller: _controller,
-              configurations: const quill.QuillEditorConfigurations(
+              config: const quill.QuillEditorConfig(
                 scrollable: true,
                 expands: true,
               ),

--- a/lib/features/structure_mindmap/structure_mindmap_screen.dart
+++ b/lib/features/structure_mindmap/structure_mindmap_screen.dart
@@ -1,6 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_treeview/flutter_treeview.dart';
-
 import '../../core/models/models.dart';
 import '../../shared/ui/glass_card.dart';
 
@@ -20,26 +18,63 @@ class StructureMindmapScreen extends StatelessWidget {
             Text('Структура главы', style: Theme.of(context).textTheme.headlineMedium),
             const SizedBox(height: 16),
             Expanded(
-              child: TreeView(
-                shrinkWrap: true,
-                controller: TreeViewController(
-                  children: nodes
-                      .map(
-                        (node) => Node(
-                          label: node.title,
-                          key: node.id,
-                          children: node.children
-                              .map((child) => Node(label: child.title, key: child.id))
-                              .toList(),
-                        ),
-                      )
-                      .toList(),
-                ),
+              child: ListView(
+                padding: EdgeInsets.zero,
+                children:
+                    nodes.map((node) => _StructureNode(node: node)).toList(),
               ),
             ),
           ],
         ),
       ),
+    );
+  }
+}
+
+class _StructureNode extends StatelessWidget {
+  const _StructureNode({required this.node, this.depth = 0});
+
+  final SceneNode node;
+  final int depth;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final children = <Widget>[
+      Padding(
+        padding: EdgeInsets.only(left: depth * 16.0, top: 4, bottom: 4),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Icon(Icons.circle, size: 8, color: theme.colorScheme.primary),
+            const SizedBox(width: 8),
+            Expanded(
+              child: Text(
+                node.title,
+                style: theme.textTheme.bodyLarge,
+              ),
+            ),
+          ],
+        ),
+      ),
+    ];
+
+    if (node.children.isNotEmpty) {
+      children.addAll(
+        node.children
+            .map(
+              (child) => _StructureNode(
+                node: child,
+                depth: depth + 1,
+              ),
+            )
+            .toList(),
+      );
+    }
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: children,
     );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,7 +19,6 @@ dependencies:
   flutter_quill: ^11.4.2
   record: ^6.1.1
   just_audio: ^0.10.5
-  flutter_treeview: ^1.0.7
   drag_and_drop_lists: ^0.4.2
   reorderables: ^0.6.0
   hive: ^2.2.3


### PR DESCRIPTION
## Summary
- replace the removed GoRouter URL strategy helper with Flutter's web url strategy
- update the chapter editor to use the current QuillEditor configuration API
- drop the flutter_treeview dependency and render the structure mindmap with a simple recursive list

## Testing
- not run (Flutter/Dart tooling unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_b_68d70081e1088322b45c0cc9213808b1