### PR TITLE
Revamp Voicebook UI screens with full design pass

### DIFF
--- a/lib/features/ai_composer/ai_composer_drawer.dart
+++ b/lib/features/ai_composer/ai_composer_drawer.dart
@@ -1,42 +1,148 @@
 import 'package:flutter/material.dart';
 
-class AiComposerDrawer extends StatelessWidget {
+class AiComposerDrawer extends StatefulWidget {
   const AiComposerDrawer({super.key});
 
   @override
+  State<AiComposerDrawer> createState() => _AiComposerDrawerState();
+}
+
+class _AiComposerDrawerState extends State<AiComposerDrawer> {
+  double temperature = 0.6;
+  double editStrength = 0.5;
+  int targetLength = 3;
+  String preset = 'Художественный';
+
+  @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final presets = ['Художественный', 'Научно-популярный', 'Эссе', 'Диалог'];
+
     return Drawer(
+      width: 420,
+      elevation: 12,
       child: SafeArea(
         child: Padding(
           padding: const EdgeInsets.all(24),
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              Text('AI Composer', style: Theme.of(context).textTheme.headlineMedium),
+              Row(
+                children: [
+                  Icon(Icons.auto_awesome, color: theme.colorScheme.primary),
+                  const SizedBox(width: 12),
+                  Text('AI Composer', style: theme.textTheme.headlineMedium),
+                ],
+              ),
               const SizedBox(height: 16),
-              const Text('Выберите действие, чтобы улучшить текст.'),
+              Text('Выберите стилистический пресет', style: theme.textTheme.titleSmall),
+              const SizedBox(height: 12),
+              Wrap(
+                spacing: 8,
+                runSpacing: 8,
+                children: presets
+                    .map(
+                      (item) => ChoiceChip(
+                        label: Text(item),
+                        selected: preset == item,
+                        onSelected: (_) => setState(() => preset = item),
+                      ),
+                    )
+                    .toList(),
+              ),
               const SizedBox(height: 24),
+              _SliderTile(
+                title: 'Температура',
+                subtitle: '0.0 — консервативно, 1.0 — творчески',
+                value: temperature,
+                onChanged: (value) => setState(() => temperature = value),
+              ),
+              _SliderTile(
+                title: 'Сила редактуры',
+                subtitle: 'Насколько сильно менять исходный текст',
+                value: editStrength,
+                onChanged: (value) => setState(() => editStrength = value),
+              ),
+              _StepperTile(
+                title: 'Целевая длина',
+                subtitle: 'Количество абзацев в ответе',
+                value: targetLength,
+                onChanged: (value) => setState(() => targetLength = value),
+              ),
+              const SizedBox(height: 16),
               Wrap(
                 spacing: 12,
                 runSpacing: 12,
                 children: [
-                  _PresetChip(label: 'Художественный'),
-                  _PresetChip(label: 'Научно-популярный'),
-                  _PresetChip(label: 'Эссе'),
-                  _PresetChip(label: 'Диалог'),
+                  FilledButton.icon(
+                    onPressed: () {},
+                    icon: const Icon(Icons.description_outlined),
+                    label: const Text('Синопсис'),
+                  ),
+                  FilledButton.icon(
+                    onPressed: () {},
+                    icon: const Icon(Icons.auto_stories),
+                    label: const Text('План + сцены'),
+                  ),
+                  FilledButton.icon(
+                    onPressed: () {},
+                    icon: const Icon(Icons.merge_type),
+                    label: const Text('Мостик'),
+                  ),
+                  FilledButton.icon(
+                    onPressed: () {},
+                    icon: const Icon(Icons.sparkles),
+                    label: const Text('Сделать художественнее'),
+                  ),
                 ],
               ),
-              const SizedBox(height: 24),
-              FilledButton.icon(
-                onPressed: () {},
-                icon: const Icon(Icons.auto_awesome),
-                label: const Text('Расширить'),
+              const SizedBox(height: 16),
+              Container(
+                padding: const EdgeInsets.all(16),
+                decoration: BoxDecoration(
+                  borderRadius: BorderRadius.circular(16),
+                  color: theme.colorScheme.surfaceVariant.withOpacity(0.6),
+                ),
+                child: Row(
+                  children: [
+                    Icon(Icons.info_outline, color: theme.colorScheme.primary),
+                    const SizedBox(width: 12),
+                    Expanded(
+                      child: Text(
+                        'Выделите фрагмент текста в редакторе, чтобы применить дифф.',
+                        style: theme.textTheme.bodyMedium,
+                      ),
+                    ),
+                  ],
+                ),
               ),
-              const SizedBox(height: 12),
-              FilledButton.icon(
-                onPressed: () {},
-                icon: const Icon(Icons.swap_calls),
-                label: const Text('Перефразировать'),
+              const SizedBox(height: 16),
+              Expanded(
+                child: GlassPreview(
+                  before: '— Он исчез в тумане станции, — прошептала Ина.\n— Мы ещё вернём его голос, ответил оператор.',
+                  after:
+                      '— Он растаял в свете ночной станции, — тихо произнесла Ина.\n— Мы обязательно вернём его голос, — уверенно ответил оператор, настраивая микшер.',
+                ),
+              ),
+              const SizedBox(height: 16),
+              Row(
+                children: [
+                  FilledButton.icon(
+                    onPressed: () {},
+                    icon: const Icon(Icons.check_circle),
+                    label: const Text('Принять всё'),
+                  ),
+                  const SizedBox(width: 12),
+                  OutlinedButton(
+                    onPressed: () {},
+                    child: const Text('Принять выделенное'),
+                  ),
+                  const Spacer(),
+                  TextButton(
+                    onPressed: () {},
+                    child: const Text('Отменить'),
+                  ),
+                ],
               ),
             ],
           ),
@@ -46,13 +152,188 @@ class AiComposerDrawer extends StatelessWidget {
   }
 }
 
-class _PresetChip extends StatelessWidget {
-  const _PresetChip({required this.label});
+class _SliderTile extends StatelessWidget {
+  const _SliderTile({
+    required this.title,
+    required this.subtitle,
+    required this.value,
+    required this.onChanged,
+  });
 
-  final String label;
+  final String title;
+  final String subtitle;
+  final double value;
+  final ValueChanged<double> onChanged;
 
   @override
   Widget build(BuildContext context) {
-    return FilterChip(label: Text(label), selected: true, onSelected: (_) {});
+    final theme = Theme.of(context);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(title, style: theme.textTheme.titleMedium),
+        Text(subtitle, style: theme.textTheme.bodySmall),
+        Slider(
+          value: value,
+          onChanged: onChanged,
+        ),
+      ],
+    );
+  }
+}
+
+class _StepperTile extends StatelessWidget {
+  const _StepperTile({
+    required this.title,
+    required this.subtitle,
+    required this.value,
+    required this.onChanged,
+  });
+
+  final String title;
+  final String subtitle;
+  final int value;
+  final ValueChanged<int> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Row(
+      children: [
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(title, style: theme.textTheme.titleMedium),
+              Text(subtitle, style: theme.textTheme.bodySmall),
+            ],
+          ),
+        ),
+        IconButton(
+          onPressed: value > 1 ? () => onChanged(value - 1) : null,
+          icon: const Icon(Icons.remove_circle_outline),
+        ),
+        Text('$value', style: theme.textTheme.titleLarge),
+        IconButton(
+          onPressed: () => onChanged(value + 1),
+          icon: const Icon(Icons.add_circle_outline),
+        ),
+      ],
+    );
+  }
+}
+
+class GlassPreview extends StatelessWidget {
+  const GlassPreview({super.key, required this.before, required this.after});
+
+  final String before;
+  final String after;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(color: theme.colorScheme.outlineVariant),
+      ),
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Text('Diff-превью', style: theme.textTheme.titleMedium),
+              const Spacer(),
+              SegmentedButton<String>(
+                segments: const [
+                  ButtonSegment(value: 'inline', label: Text('Inline')),
+                  ButtonSegment(value: 'side', label: Text('Side-by-side')),
+                ],
+                selected: const {'inline'},
+                onSelectionChanged: (_) {},
+              ),
+            ],
+          ),
+          const Divider(height: 24),
+          Expanded(
+            child: Row(
+              children: [
+                Expanded(
+                  child: _DiffBlock(
+                    title: 'Было',
+                    text: before,
+                    color: Colors.redAccent.withOpacity(0.1),
+                    bullet: '-',
+                  ),
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: _DiffBlock(
+                    title: 'Стало',
+                    text: after,
+                    color: Colors.greenAccent.withOpacity(0.12),
+                    bullet: '+',
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _DiffBlock extends StatelessWidget {
+  const _DiffBlock({
+    required this.title,
+    required this.text,
+    required this.color,
+    required this.bullet,
+  });
+
+  final String title;
+  final String text;
+  final Color color;
+  final String bullet;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(12),
+        color: color,
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(title, style: theme.textTheme.titleSmall),
+          const SizedBox(height: 12),
+          Expanded(
+            child: ListView(
+              children: text
+                  .split('\n')
+                  .map(
+                    (line) => Padding(
+                      padding: const EdgeInsets.only(bottom: 8),
+                      child: Row(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(bullet, style: theme.textTheme.titleSmall),
+                          const SizedBox(width: 8),
+                          Expanded(child: Text(line, style: theme.textTheme.bodyMedium)),
+                        ],
+                      ),
+                    ),
+                  )
+                  .toList(),
+            ),
+          ),
+        ],
+      ),
+    );
   }
 }

--- a/lib/features/book_workspace/book_workspace_screen.dart
+++ b/lib/features/book_workspace/book_workspace_screen.dart
@@ -7,7 +7,46 @@ import 'widgets/chapter_ruler/chapter_ruler.dart';
 import 'widgets/editor/chapter_editor.dart';
 import 'widgets/fab_panel/fab_action_cluster.dart';
 
-final currentChapterProvider = StateProvider<Chapter?>((ref) => null);
+final _demoChapters = [
+  Chapter(
+    id: 'ch1',
+    bookId: 'book1',
+    title: 'Пролог: Ночная станция',
+    subtitle: 'Как всё началось',
+    status: ChapterStatus.edit,
+    meta: {'genre': 'Sci-fi', 'audience': '16+', 'wordCount': '3720'},
+  ),
+  Chapter(
+    id: 'ch2',
+    bookId: 'book1',
+    title: 'Глава 1. Сигналы в тумане',
+    subtitle: 'Первые записи',
+    status: ChapterStatus.draft,
+    meta: {'genre': 'Sci-fi', 'audience': '16+', 'wordCount': '2980'},
+  ),
+  Chapter(
+    id: 'ch3',
+    bookId: 'book1',
+    title: 'Глава 2. Архив воспоминаний',
+    subtitle: 'Шёпоты железа',
+    status: ChapterStatus.draft,
+    meta: {'genre': 'Sci-fi', 'audience': '16+', 'wordCount': '4120'},
+  ),
+];
+
+final chapterSummariesProvider = StateProvider<List<ChapterSummary>>((ref) {
+  return List.generate(_demoChapters.length, (index) {
+    final chapter = _demoChapters[index];
+    return ChapterSummary(
+      id: chapter.id,
+      title: chapter.title,
+      order: index,
+      wordCount: 3500 + index * 620,
+    );
+  });
+});
+
+final currentChapterProvider = StateProvider<Chapter>((ref) => _demoChapters.first);
 
 class BookWorkspaceScreen extends ConsumerWidget {
   const BookWorkspaceScreen({super.key, required this.bookId});
@@ -16,6 +55,7 @@ class BookWorkspaceScreen extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final summaries = ref.watch(chapterSummariesProvider);
     final chapter = ref.watch(currentChapterProvider);
 
     return LayoutBuilder(
@@ -24,12 +64,26 @@ class BookWorkspaceScreen extends ConsumerWidget {
         final isTablet = constraints.maxWidth >= 600 && constraints.maxWidth < 1024;
 
         final ruler = SizedBox(
-          width: isDesktop ? 88 : 64,
+          width: isDesktop ? 104 : 84,
           child: ChapterRuler(
-            chapters: const [],
-            onSelect: (_) {},
+            chapters: summaries,
+            activeChapterId: chapter.id,
+            onSelect: (chapterId) {
+              final next = _demoChapters.firstWhere((element) => element.id == chapterId);
+              ref.read(currentChapterProvider.notifier).state = next;
+            },
             onAdd: () {},
-            onReorder: (oldIndex, newIndex) {},
+            onReorder: (oldIndex, newIndex) {
+              final notifier = ref.read(chapterSummariesProvider.notifier);
+              final list = [...notifier.state];
+              if (newIndex > oldIndex) newIndex -= 1;
+              final item = list.removeAt(oldIndex);
+              list.insert(newIndex, item.copyWith(order: newIndex));
+              notifier.state = [
+                for (var i = 0; i < list.length; i++)
+                  list[i].copyWith(order: i),
+              ];
+            },
           ),
         );
 
@@ -63,7 +117,7 @@ class BookWorkspaceScreen extends ConsumerWidget {
                   Expanded(
                     child: Stack(
                       children: [
-                        Container(),
+                        const SizedBox.expand(),
                         fabPanel,
                       ],
                     ),
@@ -78,7 +132,7 @@ class BookWorkspaceScreen extends ConsumerWidget {
           body: SafeArea(
             child: Column(
               children: [
-                SizedBox(height: isTablet ? 88 : 72, child: ruler),
+                SizedBox(height: isTablet ? 96 : 82, child: ruler),
                 Expanded(child: editor),
               ],
             ),

--- a/lib/features/book_workspace/widgets/chapter_ruler/chapter_ruler.dart
+++ b/lib/features/book_workspace/widgets/chapter_ruler/chapter_ruler.dart
@@ -10,88 +10,171 @@ class ChapterRuler extends StatelessWidget {
     required this.onSelect,
     required this.onAdd,
     required this.onReorder,
+    this.activeChapterId,
   });
 
   final List<ChapterSummary> chapters;
   final ValueChanged<String> onSelect;
   final VoidCallback onAdd;
   final void Function(int from, int to) onReorder;
+  final String? activeChapterId;
 
   @override
   Widget build(BuildContext context) {
-    return DecoratedBox(
-      decoration: BoxDecoration(
-        gradient: const LinearGradient(
-          colors: [AppColors.primary, AppColors.secondary],
-          begin: Alignment.topCenter,
-          end: Alignment.bottomCenter,
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(AppSpacing.radiusLarge),
+      child: Container(
+        decoration: BoxDecoration(
+          gradient: const LinearGradient(
+            colors: [AppColors.primary, AppColors.secondary],
+            begin: Alignment.topCenter,
+            end: Alignment.bottomCenter,
+          ),
+          boxShadow: [
+            BoxShadow(
+              color: AppColors.secondary.withOpacity(0.2),
+              blurRadius: 20,
+              offset: const Offset(0, 12),
+            ),
+          ],
         ),
-        borderRadius: BorderRadius.circular(AppSpacing.radiusLarge),
-      ),
-      child: Column(
-        children: [
-          Expanded(
-            child: ListView.separated(
-              padding: const EdgeInsets.symmetric(vertical: 24),
-              itemCount: chapters.length,
-              separatorBuilder: (_, __) => const SizedBox(height: 12),
-              itemBuilder: (context, index) {
-                final chapter = chapters[index];
-                return _ChapterPill(
-                  title: chapter.title,
-                  index: index + 1,
-                  onTap: () => onSelect(chapter.id),
-                );
-              },
-            ),
-          ),
-          Padding(
-            padding: const EdgeInsets.all(12),
-            child: OutlinedButton.icon(
-              style: OutlinedButton.styleFrom(
-                foregroundColor: Colors.white,
-                side: const BorderSide(color: Colors.white70),
+        child: Column(
+          children: [
+            Expanded(
+              child: ReorderableListView.builder(
+                padding: const EdgeInsets.symmetric(vertical: 24),
+                itemCount: chapters.length,
+                buildDefaultDragHandles: false,
+                onReorder: onReorder,
+                itemBuilder: (context, index) {
+                  final chapter = chapters[index];
+                  final isActive = chapter.id == activeChapterId;
+                  return Padding(
+                    key: ValueKey(chapter.id),
+                    padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+                    child: _ChapterPill(
+                      chapter: chapter,
+                      index: index,
+                      isActive: isActive,
+                      onTap: () => onSelect(chapter.id),
+                    ),
+                  );
+                },
               ),
-              onPressed: onAdd,
-              icon: const Icon(Icons.add),
-              label: const Text('Глава'),
             ),
-          ),
-        ],
+            Padding(
+              padding: const EdgeInsets.all(16),
+              child: FilledButton.icon(
+                style: FilledButton.styleFrom(
+                  backgroundColor: Colors.white.withOpacity(0.16),
+                  foregroundColor: Colors.white,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(AppSpacing.radiusMedium),
+                  ),
+                ),
+                onPressed: onAdd,
+                icon: const Icon(Icons.add),
+                label: const Text('Новая глава'),
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }
 }
 
 class _ChapterPill extends StatelessWidget {
-  const _ChapterPill({required this.title, required this.index, required this.onTap});
+  const _ChapterPill({
+    required this.chapter,
+    required this.index,
+    required this.isActive,
+    required this.onTap,
+  });
 
-  final String title;
+  final ChapterSummary chapter;
   final int index;
+  final bool isActive;
   final VoidCallback onTap;
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 12),
+    return Material(
+      color: Colors.transparent,
       child: InkWell(
         borderRadius: BorderRadius.circular(AppSpacing.radiusLarge),
         onTap: onTap,
         child: Ink(
-          padding: const EdgeInsets.symmetric(vertical: 12, horizontal: 16),
           decoration: BoxDecoration(
             borderRadius: BorderRadius.circular(AppSpacing.radiusLarge),
-            color: Colors.white.withOpacity(0.2),
+            color: isActive ? Colors.white.withOpacity(0.24) : Colors.white.withOpacity(0.12),
+            border: Border.all(
+              color: isActive ? Colors.white : Colors.white24,
+              width: isActive ? 1.6 : 1,
+            ),
           ),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
+          padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
+          child: Row(
             children: [
-              Text('Глава $index', style: theme.textTheme.labelMedium?.copyWith(color: Colors.white70)),
-              const SizedBox(height: 4),
-              Text(title, style: theme.textTheme.titleMedium?.copyWith(color: Colors.white)),
+              ReorderableDelayedDragStartListener(
+                index: index,
+                child: _DragHandle(isActive: isActive),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Text(
+                      'Глава ${index + 1}',
+                      style: theme.textTheme.labelMedium?.copyWith(color: Colors.white70),
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      chapter.title,
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                      style: theme.textTheme.titleSmall?.copyWith(color: Colors.white),
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      '${chapter.wordCount} слов',
+                      style: theme.textTheme.bodySmall?.copyWith(color: Colors.white60),
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(width: 12),
+              Icon(Icons.bookmark_add_outlined, color: Colors.white70, size: 18),
             ],
           ),
+        ),
+      ),
+    );
+  }
+}
+
+class _DragHandle extends StatelessWidget {
+  const _DragHandle({required this.isActive});
+
+  final bool isActive;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      height: 38,
+      width: 6,
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(999),
+        gradient: LinearGradient(
+          colors: [
+            Colors.white.withOpacity(0.9),
+            Colors.white.withOpacity(isActive ? 0.3 : 0.15),
+          ],
+          begin: Alignment.topCenter,
+          end: Alignment.bottomCenter,
         ),
       ),
     );

--- a/lib/features/book_workspace/widgets/editor/chapter_editor.dart
+++ b/lib/features/book_workspace/widgets/editor/chapter_editor.dart
@@ -1,53 +1,364 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_quill/flutter_quill.dart' as quill;
 
 import '../../../../core/models/models.dart';
+import '../../../../shared/tokens/design_tokens.dart';
 import '../../../../shared/ui/glass_card.dart';
 
 class ChapterEditor extends StatefulWidget {
   const ChapterEditor({super.key, required this.chapter});
 
-  final Chapter? chapter;
+  final Chapter chapter;
 
   @override
   State<ChapterEditor> createState() => _ChapterEditorState();
 }
 
 class _ChapterEditorState extends State<ChapterEditor> {
-  late final quill.QuillController _controller;
+  late quill.QuillController _controller;
+  late final ScrollController _scrollController;
+  late final FocusNode _editorFocusNode;
+  late TextEditingController _titleController;
+  late TextEditingController _subtitleController;
+  Timer? _saveTimer;
+  bool _saving = false;
 
   @override
   void initState() {
     super.initState();
-    _controller = quill.QuillController.basic();
+    _initController();
+    _scrollController = ScrollController();
+    _editorFocusNode = FocusNode();
+    _titleController = TextEditingController(text: widget.chapter.title);
+    _subtitleController = TextEditingController(text: widget.chapter.subtitle ?? '');
+  }
+
+  @override
+  void didUpdateWidget(covariant ChapterEditor oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.chapter.id != widget.chapter.id) {
+      _controller.removeListener(_scheduleAutosave);
+      _controller.dispose();
+      _initController();
+      _titleController.text = widget.chapter.title;
+      _subtitleController.text = widget.chapter.subtitle ?? '';
+    }
   }
 
   @override
   void dispose() {
     _controller.dispose();
+    _scrollController.dispose();
+    _editorFocusNode.dispose();
+    _titleController.dispose();
+    _subtitleController.dispose();
+    _saveTimer?.cancel();
     super.dispose();
+  }
+
+  void _initController() {
+    _controller = quill.QuillController.basic();
+    _controller.addListener(_scheduleAutosave);
+  }
+
+  void _scheduleAutosave() {
+    _saveTimer?.cancel();
+    setState(() => _saving = true);
+    _saveTimer = Timer(const Duration(seconds: 2), () {
+      if (mounted) {
+        setState(() => _saving = false);
+      }
+    });
   }
 
   @override
   Widget build(BuildContext context) {
-    final chapter = widget.chapter;
+    final theme = Theme.of(context);
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
-        Text(chapter?.title ?? 'Без названия', style: Theme.of(context).textTheme.headlineMedium),
-        const SizedBox(height: 12),
-        Expanded(
-          child: GlassCard(
-            child: quill.QuillEditor.basic(
-              controller: _controller,
-              config: const quill.QuillEditorConfig(
-                scrollable: true,
-                expands: true,
+        GlassCard(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        TextField(
+                          controller: _titleController,
+                          style: theme.textTheme.headlineMedium,
+                          decoration: const InputDecoration(
+                            border: InputBorder.none,
+                            hintText: 'Заголовок главы',
+                          ),
+                          onChanged: (_) => _scheduleAutosave(),
+                        ),
+                        TextField(
+                          controller: _subtitleController,
+                          style: theme.textTheme.titleMedium?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+                          decoration: const InputDecoration(
+                            border: InputBorder.none,
+                            hintText: 'Подзаголовок',
+                          ),
+                          onChanged: (_) => _scheduleAutosave(),
+                        ),
+                      ],
+                    ),
+                  ),
+                  Column(
+                    crossAxisAlignment: CrossAxisAlignment.end,
+                    children: [
+                      _SaveIndicator(isSaving: _saving),
+                      const SizedBox(height: 12),
+                      _WordCountChip(count: widget.chapter.meta['wordCount'] ?? '—'),
+                    ],
+                  ),
+                ],
               ),
-            ),
+              const SizedBox(height: 12),
+              Wrap(
+                spacing: 8,
+                runSpacing: 8,
+                children: [
+                  _MetaChip(label: 'Жанр: ${widget.chapter.meta['genre'] ?? '—'}'),
+                  _MetaChip(label: 'ЦА: ${widget.chapter.meta['audience'] ?? '—'}'),
+                  _StatusBadge(status: widget.chapter.status),
+                  OutlinedButton.icon(
+                    onPressed: () {},
+                    icon: const Icon(Icons.account_tree_outlined),
+                    label: const Text('Структура'),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+        const SizedBox(height: 20),
+        Expanded(
+          child: Stack(
+            children: [
+              GlassCard(
+                padding: EdgeInsets.zero,
+                child: Column(
+                  children: [
+                    _EditorToolbar(onCommand: (command) {}),
+                    const Divider(height: 1),
+                    Expanded(
+                      child: quill.QuillEditor.basic(
+                        controller: _controller,
+                        focusNode: _editorFocusNode,
+                        scrollController: _scrollController,
+                        configurations: const quill.QuillEditorConfigurations(
+                          expands: true,
+                          placeholder: 'Начните диктовать или печатать...',
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              Positioned(
+                top: 24,
+                right: 24,
+                child: _AiHintCard(onAction: (action) {}),
+              ),
+            ],
           ),
         ),
       ],
+    );
+  }
+}
+
+class _EditorToolbar extends StatelessWidget {
+  const _EditorToolbar({required this.onCommand});
+
+  final ValueChanged<String> onCommand;
+
+  @override
+  Widget build(BuildContext context) {
+    final buttons = [
+      _ToolbarButton(icon: Icons.undo, label: 'Назад'),
+      _ToolbarButton(icon: Icons.redo, label: 'Вперёд'),
+      const SizedBox(width: 12),
+      _ToolbarButton(icon: Icons.format_bold, label: 'Жирный'),
+      _ToolbarButton(icon: Icons.format_italic, label: 'Курсив'),
+      _ToolbarButton(icon: Icons.title, label: 'H1'),
+      _ToolbarButton(icon: Icons.subtitles_outlined, label: 'H2'),
+      _ToolbarButton(icon: Icons.format_list_bulleted, label: 'Список'),
+      _ToolbarButton(icon: Icons.format_quote, label: 'Цитата'),
+      _ToolbarButton(icon: Icons.code, label: 'Код'),
+    ];
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.surface.withOpacity(0.7),
+        borderRadius: const BorderRadius.vertical(top: Radius.circular(AppSpacing.radiusMedium)),
+      ),
+      child: SingleChildScrollView(
+        scrollDirection: Axis.horizontal,
+        child: Row(children: buttons.map((b) => Padding(padding: const EdgeInsets.symmetric(horizontal: 4), child: b)).toList()),
+      ),
+    );
+  }
+}
+
+class _ToolbarButton extends StatelessWidget {
+  const _ToolbarButton({required this.icon, required this.label});
+
+  final IconData icon;
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return FilledButton.tonalIcon(
+      onPressed: () {},
+      icon: Icon(icon, size: 18),
+      label: Text(label),
+    );
+  }
+}
+
+class _MetaChip extends StatelessWidget {
+  const _MetaChip({required this.label});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Chip(
+      label: Text(label),
+      backgroundColor: Theme.of(context).colorScheme.primary.withOpacity(0.08),
+      labelStyle: Theme.of(context).textTheme.bodyMedium,
+      side: BorderSide(color: Theme.of(context).colorScheme.primary.withOpacity(0.2)),
+    );
+  }
+}
+
+class _StatusBadge extends StatelessWidget {
+  const _StatusBadge({required this.status});
+
+  final ChapterStatus status;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final map = {
+      ChapterStatus.draft: ('Черновик', colorScheme.primary),
+      ChapterStatus.edit: ('Редактура', AppColors.accent),
+      ChapterStatus.final_: ('Финал', Colors.greenAccent.shade400),
+    };
+    final data = map[status]!;
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
+      decoration: BoxDecoration(
+        color: data.$2.withOpacity(0.16),
+        borderRadius: BorderRadius.circular(999),
+        border: Border.all(color: data.$2.withOpacity(0.4)),
+      ),
+      child: Text(data.$1, style: Theme.of(context).textTheme.labelMedium?.copyWith(color: data.$2)),
+    );
+  }
+}
+
+class _SaveIndicator extends StatelessWidget {
+  const _SaveIndicator({required this.isSaving});
+
+  final bool isSaving;
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedSwitcher(
+      duration: const Duration(milliseconds: 250),
+      child: isSaving
+          ? Row(
+              key: const ValueKey('saving'),
+              children: const [
+                SizedBox(
+                  width: 16,
+                  height: 16,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                ),
+                SizedBox(width: 8),
+                Text('Сохраняем...'),
+              ],
+            )
+          : Row(
+              key: const ValueKey('saved'),
+              children: const [
+                Icon(Icons.check_circle, color: Colors.greenAccent, size: 18),
+                SizedBox(width: 8),
+                Text('Сохранено'),
+              ],
+            ),
+    );
+  }
+}
+
+class _WordCountChip extends StatelessWidget {
+  const _WordCountChip({required this.count});
+
+  final String count;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(999),
+        color: Theme.of(context).colorScheme.primary.withOpacity(0.12),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const Icon(Icons.speed, size: 16),
+          const SizedBox(width: 6),
+          Text('$count слов'),
+        ],
+      ),
+    );
+  }
+}
+
+class _AiHintCard extends StatelessWidget {
+  const _AiHintCard({required this.onAction});
+
+  final ValueChanged<String> onAction;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return GlassCard(
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Row(
+            children: [
+              Icon(Icons.auto_awesome, color: theme.colorScheme.primary),
+              const SizedBox(width: 8),
+              Text('AI подсказки', style: theme.textTheme.titleMedium),
+            ],
+          ),
+          const SizedBox(height: 12),
+          Wrap(
+            spacing: 8,
+            children: [
+              ActionChip(label: const Text('Расширить'), onPressed: () => onAction('expand')),
+              ActionChip(label: const Text('Перефразировать'), onPressed: () => onAction('rephrase')),
+              ActionChip(label: const Text('Упростить'), onPressed: () => onAction('simplify')),
+            ],
+          ),
+        ],
+      ),
     );
   }
 }

--- a/lib/features/book_workspace/widgets/fab_panel/fab_action_cluster.dart
+++ b/lib/features/book_workspace/widgets/fab_panel/fab_action_cluster.dart
@@ -1,3 +1,5 @@
+import 'dart:math' as math;
+
 import 'package:flutter/material.dart';
 
 import '../../../../shared/tokens/design_tokens.dart';
@@ -20,58 +22,160 @@ class FabActionCluster extends StatelessWidget {
       mainAxisSize: MainAxisSize.min,
       crossAxisAlignment: CrossAxisAlignment.end,
       children: [
-        _ActionButton(
+        _FloatingActionButton(
           icon: Icons.auto_fix_high,
           label: 'Сформировать текст',
+          color: AppColors.secondary,
           onPressed: onOpenComposer,
         ),
         const SizedBox(height: 12),
-        _ActionButton(
-          icon: Icons.spatial_audio,
+        _FloatingActionButton(
+          icon: Icons.graphic_eq,
           label: 'Озвучить',
+          color: AppColors.accent,
           onPressed: onPreviewTts,
         ),
         const SizedBox(height: 16),
-        MicRecordButton(onPressed: onStartStop),
+        _MicRecordButton(onPressed: onStartStop),
       ],
     );
   }
 }
 
-class MicRecordButton extends StatelessWidget {
-  const MicRecordButton({super.key, required this.onPressed});
+class _FloatingActionButton extends StatelessWidget {
+  const _FloatingActionButton({
+    required this.icon,
+    required this.label,
+    required this.color,
+    required this.onPressed,
+  });
 
+  final IconData icon;
+  final String label;
+  final Color color;
   final VoidCallback onPressed;
 
   @override
   Widget build(BuildContext context) {
-    return ElevatedButton(
-      style: ElevatedButton.styleFrom(
-        shape: const CircleBorder(),
-        padding: const EdgeInsets.all(20),
-        backgroundColor: AppColors.error,
-        foregroundColor: Colors.white,
-        elevation: 6,
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(AppSpacing.radiusLarge),
+        boxShadow: [
+          BoxShadow(color: color.withOpacity(0.28), blurRadius: 18, offset: const Offset(0, 8)),
+        ],
       ),
-      onPressed: onPressed,
-      child: const Icon(Icons.mic, size: 32),
+      child: FilledButton.icon(
+        onPressed: onPressed,
+        icon: Icon(icon),
+        label: Text(label),
+        style: FilledButton.styleFrom(
+          backgroundColor: color,
+          foregroundColor: Colors.white,
+          padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 14),
+          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(AppSpacing.radiusLarge)),
+        ),
+      ),
     );
   }
 }
 
-class _ActionButton extends StatelessWidget {
-  const _ActionButton({required this.icon, required this.label, required this.onPressed});
+class _MicRecordButton extends StatefulWidget {
+  const _MicRecordButton({required this.onPressed});
 
-  final IconData icon;
-  final String label;
   final VoidCallback onPressed;
 
   @override
+  State<_MicRecordButton> createState() => _MicRecordButtonState();
+}
+
+class _MicRecordButtonState extends State<_MicRecordButton> with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(vsync: this, duration: const Duration(seconds: 2))..repeat();
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
-    return FilledButton.icon(
-      onPressed: onPressed,
-      icon: Icon(icon),
-      label: Text(label),
+    return AnimatedBuilder(
+      animation: _controller,
+      builder: (context, child) {
+        final pulse = (math.sin(_controller.value * math.pi * 2) + 1) / 2;
+        return Stack(
+          alignment: Alignment.center,
+          children: [
+            Container(
+              width: 92 + pulse * 16,
+              height: 92 + pulse * 16,
+              decoration: BoxDecoration(
+                shape: BoxShape.circle,
+                gradient: RadialGradient(
+                  colors: [
+                    AppColors.error.withOpacity(0.45 - pulse * 0.2),
+                    AppColors.error.withOpacity(0.1),
+                  ],
+                ),
+              ),
+            ),
+            ElevatedButton(
+              style: ElevatedButton.styleFrom(
+                shape: const CircleBorder(),
+                padding: const EdgeInsets.all(28),
+                backgroundColor: AppColors.error,
+                foregroundColor: Colors.white,
+                elevation: 10,
+              ),
+              onPressed: widget.onPressed,
+              child: const Icon(Icons.mic, size: 36),
+            ),
+            Positioned(
+              bottom: -12,
+              child: _LevelMeter(level: pulse),
+            ),
+          ],
+        );
+      },
+    );
+  }
+}
+
+class _LevelMeter extends StatelessWidget {
+  const _LevelMeter({required this.level});
+
+  final double level;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 76,
+      height: 18,
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(999),
+        border: Border.all(color: Colors.white24),
+        color: Colors.black.withOpacity(0.24),
+      ),
+      padding: const EdgeInsets.all(3),
+      child: Align(
+        alignment: Alignment.centerLeft,
+        child: AnimatedContainer(
+          duration: const Duration(milliseconds: 200),
+          width: 70 * level.clamp(0.1, 1.0),
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(999),
+            gradient: const LinearGradient(
+              colors: [AppColors.accent, Colors.white],
+            ),
+          ),
+        ),
+      ),
     );
   }
 }

--- a/lib/features/export/export_screen.dart
+++ b/lib/features/export/export_screen.dart
@@ -9,35 +9,180 @@ class ExportScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final textFormats = ['Markdown', 'DOCX', 'EPUB', 'PDF'];
+    final audioFormats = ['MP3', 'M4B'];
+
     return Scaffold(
       appBar: AppBar(title: const Text('Экспорт')),
       body: Padding(
         padding: const EdgeInsets.all(24),
-        child: GlassCard(
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text('Экспорт книги', style: Theme.of(context).textTheme.headlineMedium),
-              const SizedBox(height: 16),
-              const Text('Выберите формат для текста и аудио.'),
-              const SizedBox(height: 24),
-              Wrap(
-                spacing: 12,
-                children: const [
-                  ChoiceChip(label: Text('Markdown'), selected: true),
-                  ChoiceChip(label: Text('DOCX'), selected: false),
-                  ChoiceChip(label: Text('EPUB'), selected: false),
+        child: Row(
+          children: [
+            Expanded(
+              flex: 2,
+              child: GlassCard(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text('Текстовые форматы', style: Theme.of(context).textTheme.headlineSmall),
+                    const SizedBox(height: 12),
+                    Wrap(
+                      spacing: 12,
+                      children: textFormats
+                          .map((format) => ChoiceChip(label: Text(format), selected: format == 'EPUB', onSelected: (_) {}))
+                          .toList(),
+                    ),
+                    const SizedBox(height: 24),
+                    Text('Метаданные', style: Theme.of(context).textTheme.titleMedium),
+                    const SizedBox(height: 12),
+                    TextField(
+                      decoration: InputDecoration(
+                        labelText: 'Название книги',
+                        filled: true,
+                        fillColor: Theme.of(context).colorScheme.surfaceVariant.withOpacity(0.5),
+                        border: OutlineInputBorder(borderRadius: BorderRadius.circular(16), borderSide: BorderSide.none),
+                      ),
+                    ),
+                    const SizedBox(height: 12),
+                    TextField(
+                      maxLines: 3,
+                      decoration: InputDecoration(
+                        labelText: 'Аннотация',
+                        filled: true,
+                        fillColor: Theme.of(context).colorScheme.surfaceVariant.withOpacity(0.5),
+                        border: OutlineInputBorder(borderRadius: BorderRadius.circular(16), borderSide: BorderSide.none),
+                      ),
+                    ),
+                    const SizedBox(height: 12),
+                    TextField(
+                      decoration: InputDecoration(
+                        labelText: 'Жанры и ключевые слова',
+                        filled: true,
+                        fillColor: Theme.of(context).colorScheme.surfaceVariant.withOpacity(0.5),
+                        border: OutlineInputBorder(borderRadius: BorderRadius.circular(16), borderSide: BorderSide.none),
+                      ),
+                    ),
+                    const SizedBox(height: 20),
+                    _TocList(),
+                    const SizedBox(height: 20),
+                    FilledButton.icon(
+                      onPressed: () {},
+                      icon: const Icon(Icons.download),
+                      label: const Text('Экспортировать текст'),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+            const SizedBox(width: 24),
+            Expanded(
+              child: Column(
+                children: [
+                  Expanded(
+                    child: GlassCard(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text('Аудио', style: Theme.of(context).textTheme.headlineSmall),
+                          const SizedBox(height: 12),
+                          Wrap(
+                            spacing: 12,
+                            children: audioFormats
+                                .map((format) => ChoiceChip(label: Text(format), selected: format == 'M4B', onSelected: (_) {}))
+                                .toList(),
+                          ),
+                          const SizedBox(height: 20),
+                          ListTile(
+                            contentPadding: EdgeInsets.zero,
+                            title: const Text('Голос'),
+                            subtitle: const Text('Автор: Night Station'),
+                            trailing: const Icon(Icons.chevron_right),
+                            onTap: () {},
+                          ),
+                          const SizedBox(height: 12),
+                          _SliderTile(
+                            label: 'Скорость',
+                            value: 1.0,
+                            onChanged: (_) {},
+                          ),
+                          _SliderTile(
+                            label: 'Тон',
+                            value: 0.5,
+                            onChanged: (_) {},
+                          ),
+                          const SizedBox(height: 20),
+                          FilledButton.icon(
+                            onPressed: () {},
+                            icon: const Icon(Icons.spatial_audio_off),
+                            label: const Text('Сгенерировать аудио'),
+                          ),
+                          const SizedBox(height: 12),
+                          const LinearProgressIndicator(value: 0.45),
+                        ],
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: 24),
+                  GlassCard(
+                    child: Row(
+                      children: const [
+                        Icon(Icons.info_outline),
+                        SizedBox(width: 12),
+                        Expanded(child: Text('Экспорт EPUB включает оглавление и пометку «Синтетическая озвучка» для аудио.')),
+                      ],
+                    ),
+                  ),
                 ],
               ),
-              const SizedBox(height: 24),
-              FilledButton.icon(
-                onPressed: () {},
-                icon: const Icon(Icons.download),
-                label: const Text('Экспортировать'),
-              ),
-            ],
-          ),
+            ),
+          ],
         ),
+      ),
+    );
+  }
+}
+
+class _SliderTile extends StatelessWidget {
+  const _SliderTile({required this.label, required this.value, required this.onChanged});
+
+  final String label;
+  final double value;
+  final ValueChanged<double> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(label),
+        Slider(
+          value: value,
+          onChanged: onChanged,
+        ),
+      ],
+    );
+  }
+}
+
+class _TocList extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    final chapters = List.generate(6, (index) => 'Глава ${index + 1}');
+    return GlassCard(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text('Оглавление', style: Theme.of(context).textTheme.titleMedium),
+          const SizedBox(height: 12),
+          ...chapters.map(
+            (title) => CheckboxListTile(
+              value: true,
+              onChanged: (_) {},
+              title: Text(title),
+              controlAffinity: ListTileControlAffinity.leading,
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/lib/features/library/library_screen.dart
+++ b/lib/features/library/library_screen.dart
@@ -3,12 +3,41 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../core/models/models.dart';
 import '../../shared/tokens/design_tokens.dart';
-import '../../shared/ui/glass_app_bar.dart';
 import '../../shared/ui/glass_card.dart';
-import '../../shared/ui/primary_button.dart';
+import '../../shared/ui/glass_search_field.dart';
 import 'widgets/notebook_card.dart';
 
-final notebooksProvider = StateProvider<List<Notebook>>((ref) => const []);
+final notebooksProvider = StateProvider<List<Notebook>>((ref) {
+  return [
+    Notebook(
+      id: '1',
+      title: 'Город из тумана',
+      tags: const ['Фантастика', 'Draft'],
+      updatedAt: DateTime.now(),
+      chapters: 12,
+      words: 45213,
+      audioMinutes: 95,
+    ),
+    Notebook(
+      id: '2',
+      title: 'Практическое руководство по речи',
+      tags: const ['Non-fiction'],
+      updatedAt: DateTime.now().subtract(const Duration(days: 1)),
+      chapters: 8,
+      words: 28340,
+      audioMinutes: 61,
+    ),
+    Notebook(
+      id: '3',
+      title: 'Записки путешественника',
+      tags: const ['Эссе', 'Audio-ready'],
+      updatedAt: DateTime.now().subtract(const Duration(days: 3)),
+      chapters: 15,
+      words: 67201,
+      audioMinutes: 120,
+    ),
+  ];
+});
 
 class LibraryScreen extends ConsumerWidget {
   const LibraryScreen({super.key});
@@ -18,50 +47,111 @@ class LibraryScreen extends ConsumerWidget {
     final notebooks = ref.watch(notebooksProvider);
 
     return Scaffold(
-      appBar: GlassAppBar(
-        title: 'Библиотека',
-        actions: [
-          IconButton(
-            icon: const Icon(Icons.search),
-            onPressed: () {},
-          ),
-        ],
-      ),
       body: Padding(
         padding: const EdgeInsets.all(AppSpacing.outer),
-        child: notebooks.isEmpty
-            ? Center(
-                child: GlassCard(
-                  child: Column(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      Text('Создайте свою первую книгу',
-                          style: Theme.of(context).textTheme.headlineMedium),
-                      const SizedBox(height: 16),
-                      const PrimaryButton(label: 'Новая книга', onPressed: null, icon: Icons.add),
-                    ],
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Row(
+              children: [
+                Expanded(
+                  child: GlassSearchField(
+                    hintText: 'Поиск по библиотеке',
+                    onChanged: (_) {},
                   ),
                 ),
-              )
-            : GridView.builder(
-                itemCount: notebooks.length,
-                gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-                  crossAxisCount: 3,
-                  crossAxisSpacing: AppSpacing.gutter,
-                  mainAxisSpacing: AppSpacing.gutter,
-                  childAspectRatio: 0.72,
+                const SizedBox(width: 16),
+                FilledButton.icon(
+                  onPressed: () {},
+                  icon: const Icon(Icons.tune),
+                  label: const Text('Фильтры'),
                 ),
-                itemBuilder: (context, index) {
-                  final notebook = notebooks[index];
-                  return NotebookCard(notebook: notebook);
-                },
+              ],
+            ),
+            const SizedBox(height: 24),
+            SingleChildScrollView(
+              scrollDirection: Axis.horizontal,
+              child: Row(
+                children: const [
+                  _TagChip(label: 'Все проекты', selected: true),
+                  SizedBox(width: 12),
+                  _TagChip(label: 'Черновики'),
+                  SizedBox(width: 12),
+                  _TagChip(label: 'Готово к озвучке'),
+                  SizedBox(width: 12),
+                  _TagChip(label: 'Избранное'),
+                ],
               ),
+            ),
+            const SizedBox(height: 32),
+            Expanded(
+              child: notebooks.isEmpty
+                  ? Center(
+                      child: GlassCard(
+                        child: Column(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            Text('Создайте свою первую книгу',
+                                style: Theme.of(context).textTheme.headlineMedium),
+                            const SizedBox(height: 16),
+                            FilledButton.icon(
+                              onPressed: () {},
+                              icon: const Icon(Icons.add),
+                              label: const Text('Новая книга'),
+                            ),
+                          ],
+                        ),
+                      ),
+                    )
+                  : LayoutBuilder(
+                      builder: (context, constraints) {
+                        final crossAxisCount = constraints.maxWidth ~/ 260;
+                        return GridView.builder(
+                          gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+                            crossAxisCount: crossAxisCount.clamp(1, 5),
+                            crossAxisSpacing: AppSpacing.gutter,
+                            mainAxisSpacing: AppSpacing.gutter,
+                            childAspectRatio: 0.72,
+                          ),
+                          itemCount: notebooks.length,
+                          itemBuilder: (context, index) {
+                            final notebook = notebooks[index];
+                            return NotebookCard(notebook: notebook);
+                          },
+                        );
+                      },
+                    ),
+            ),
+          ],
+        ),
       ),
       floatingActionButton: FloatingActionButton.extended(
         onPressed: () {},
         icon: const Icon(Icons.add),
         label: const Text('Новая книга'),
       ),
+    );
+  }
+}
+
+class _TagChip extends StatelessWidget {
+  const _TagChip({required this.label, this.selected = false});
+
+  final String label;
+  final bool selected;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return FilterChip(
+      label: Text(label),
+      selected: selected,
+      onSelected: (_) {},
+      selectedColor: theme.colorScheme.primary.withOpacity(0.16),
+      backgroundColor: theme.colorScheme.surface.withOpacity(0.08),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(AppSpacing.radiusLarge)),
+      side: BorderSide(color: theme.colorScheme.primary.withOpacity(0.2)),
+      labelStyle: theme.textTheme.bodyMedium,
     );
   }
 }

--- a/lib/features/library/widgets/notebook_card.dart
+++ b/lib/features/library/widgets/notebook_card.dart
@@ -11,48 +11,144 @@ class NotebookCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final gradient = LinearGradient(
+      colors: [
+        AppColors.primary.withOpacity(0.9),
+        AppColors.secondary.withOpacity(0.9),
+      ],
+      begin: Alignment.topLeft,
+      end: Alignment.bottomRight,
+    );
     return InkWell(
       borderRadius: BorderRadius.circular(AppSpacing.radiusMedium),
-      onTap: () {
-        // TODO: open notebook.
-      },
+      onTap: () {},
       child: Ink(
         decoration: BoxDecoration(
           borderRadius: BorderRadius.circular(AppSpacing.radiusMedium),
-          gradient: const LinearGradient(
-            colors: [AppColors.primary, AppColors.secondary],
-            begin: Alignment.topLeft,
-            end: Alignment.bottomRight,
-          ),
+          gradient: gradient,
+          boxShadow: [
+            BoxShadow(
+              color: AppColors.secondary.withOpacity(0.2),
+              blurRadius: 18,
+              offset: const Offset(0, 12),
+            ),
+          ],
         ),
-        child: Padding(
-          padding: const EdgeInsets.all(20),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Expanded(
-                child: Align(
-                  alignment: Alignment.topRight,
-                  child: Text(
-                    '${notebook.chapters} глав',
-                    style: theme.textTheme.labelMedium!.copyWith(color: Colors.white70),
-                  ),
+        child: Stack(
+          children: [
+            Positioned.fill(
+              child: DecoratedBox(
+                decoration: BoxDecoration(
+                  borderRadius: BorderRadius.circular(AppSpacing.radiusMedium),
+                  border: Border.all(color: Colors.white.withOpacity(0.12)),
                 ),
               ),
-              Text(
-                notebook.title,
-                style: theme.textTheme.titleLarge!.copyWith(color: Colors.white),
-                maxLines: 2,
+            ),
+            Padding(
+              padding: const EdgeInsets.all(20),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Row(
+                    children: [
+                      const Icon(Icons.auto_stories_rounded, color: Colors.white70),
+                      const Spacer(),
+                      _NotebookMenu(onSelected: (_) {}),
+                    ],
+                  ),
+                  const Spacer(),
+                  Text(
+                    notebook.title,
+                    style: theme.textTheme.titleLarge!.copyWith(color: Colors.white),
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  const SizedBox(height: 12),
+                  Wrap(
+                    spacing: 8,
+                    runSpacing: 8,
+                    children: [
+                      _TagChip(label: '${notebook.chapters} глав'),
+                      _TagChip(label: '${notebook.words ~/ 1000} тыс. слов'),
+                      if (notebook.audioMinutes > 0)
+                        _TagChip(label: '${notebook.audioMinutes.round()} мин аудио'),
+                      ...notebook.tags.map(_TagChip.new),
+                    ],
+                  ),
+                  const SizedBox(height: 16),
+                  LinearProgressIndicator(
+                    value: (notebook.chapters.clamp(0, 20)) / 20,
+                    backgroundColor: Colors.white24,
+                    color: Colors.white,
+                    minHeight: 4,
+                    borderRadius: BorderRadius.circular(4),
+                  ),
+                  const SizedBox(height: 12),
+                  Text(
+                    'Обновлено ${_formatDate(notebook.updatedAt)}',
+                    style: theme.textTheme.bodySmall?.copyWith(color: Colors.white70),
+                  ),
+                ],
               ),
-              const SizedBox(height: 12),
-              Text(
-                'Обновлено ${notebook.updatedAt}',
-                style: theme.textTheme.bodySmall?.copyWith(color: Colors.white70),
-              ),
-            ],
-          ),
+            ),
+          ],
         ),
       ),
     );
   }
+}
+
+class _NotebookMenu extends StatelessWidget {
+  const _NotebookMenu({required this.onSelected});
+
+  final ValueChanged<String> onSelected;
+
+  @override
+  Widget build(BuildContext context) {
+    return PopupMenuButton<String>(
+      iconColor: Colors.white,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(AppSpacing.radiusSmall)),
+      onSelected: onSelected,
+      itemBuilder: (context) => const [
+        PopupMenuItem(value: 'rename', child: Text('Переименовать')),
+        PopupMenuItem(value: 'duplicate', child: Text('Дублировать')),
+        PopupMenuItem(value: 'export', child: Text('Экспортировать')),
+        PopupMenuItem(value: 'archive', child: Text('Архивировать')),
+      ],
+    );
+  }
+}
+
+class _TagChip extends StatelessWidget {
+  const _TagChip(this.label);
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+      decoration: BoxDecoration(
+        color: Colors.white.withOpacity(0.18),
+        borderRadius: BorderRadius.circular(999),
+        border: Border.all(color: Colors.white.withOpacity(0.2)),
+      ),
+      child: Text(
+        label,
+        style: Theme.of(context).textTheme.labelMedium?.copyWith(color: Colors.white),
+      ),
+    );
+  }
+}
+
+String _formatDate(DateTime date) {
+  final now = DateTime.now();
+  final difference = now.difference(date);
+  if (difference.inDays >= 1) {
+    return '${difference.inDays} дн. назад';
+  }
+  if (difference.inHours >= 1) {
+    return '${difference.inHours} ч. назад';
+  }
+  return 'только что';
 }

--- a/lib/features/onboarding/onboarding_screen.dart
+++ b/lib/features/onboarding/onboarding_screen.dart
@@ -1,9 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import '../../shared/ui/glass_app_bar.dart';
-import '../../shared/ui/primary_button.dart';
-
 class OnboardingScreen extends ConsumerWidget {
   const OnboardingScreen({super.key});
 
@@ -11,51 +8,50 @@ class OnboardingScreen extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     return Scaffold(
       extendBodyBehindAppBar: true,
-      appBar: const GlassAppBar(title: 'Voicebook'),
-      body: SafeArea(
-        child: Padding(
-          padding: const EdgeInsets.all(24),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
-              Expanded(
-                child: PageView(
-                  children: const [
-                    _BenefitCard(
-                      title: 'Диктуйте, редактируйте, экспортируйте',
-                      description:
-                          'Voicebook объединяет запись, AI-редактуру и озвучку в одном пространстве.',
+      body: Stack(
+        fit: StackFit.expand,
+        children: [
+          const _AnimatedGradientBackground(),
+          SafeArea(
+            child: Padding(
+              padding: const EdgeInsets.all(24),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  const _BrandHeader(),
+                  const SizedBox(height: 24),
+                  Expanded(
+                    child: Column(
+                      children: const [
+                        Expanded(child: _HeroCarousel()),
+                        SizedBox(height: 24),
+                        _PermissionRequestRow(),
+                      ],
                     ),
-                    _BenefitCard(
-                      title: 'Работает офлайн',
-                      description:
-                          'Последние главы доступны без сети, а прогресс синхронизируется позже.',
-                    ),
-                    _BenefitCard(
-                      title: 'Ваша студия звучания',
-                      description:
-                          'Тренируйте персональный голос и создавайте аудиокниги в один клик.',
-                    ),
-                  ],
-                ),
+                  ),
+                  const SizedBox(height: 16),
+                  const _LanguageSelector(),
+                  const SizedBox(height: 24),
+                  _PrimaryCta(
+                    onPressed: () {
+                      // Permissions and navigation handled in controller.
+                    },
+                  ),
+                ],
               ),
-              const SizedBox(height: 32),
-              PrimaryButton(
-                label: 'Начать диктовку',
-                onPressed: () {
-                  // Permissions and navigation handled in controller.
-                },
-              ),
-            ],
+            ),
           ),
-        ),
+        ],
       ),
     );
   }
 }
 
-class _BenefitCard extends StatelessWidget {
-  const _BenefitCard({required this.title, required this.description});
+class _BenefitSlide extends StatelessWidget {
+  const _BenefitSlide({
+    required this.title,
+    required this.description,
+  });
 
   final String title;
   final String description;
@@ -63,21 +59,361 @@ class _BenefitCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    return Card(
-      elevation: 0,
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(24)),
-      child: Padding(
-        padding: const EdgeInsets.all(24),
-        child: Column(
+    return GlassContainer(
+      child: Row(
+        children: [
+          Expanded(
+            flex: 3,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Text(title, style: theme.textTheme.headlineLarge),
+                const SizedBox(height: 16),
+                Text(
+                  description,
+                  style: theme.textTheme.bodyLarge,
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(width: 24),
+          Expanded(
+            flex: 2,
+            child: AspectRatio(
+              aspectRatio: 4 / 5,
+              child: DecoratedBox(
+                decoration: BoxDecoration(
+                  borderRadius: BorderRadius.circular(24),
+                  gradient: const LinearGradient(
+                    colors: [Color(0x336366F1), Color(0x338B5CF6)],
+                    begin: Alignment.topLeft,
+                    end: Alignment.bottomRight,
+                  ),
+                ),
+                child: Center(
+                  child: Icon(
+                    Icons.auto_awesome,
+                    color: theme.colorScheme.primary,
+                    size: 72,
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _AnimatedGradientBackground extends StatefulWidget {
+  const _AnimatedGradientBackground();
+
+  @override
+  State<_AnimatedGradientBackground> createState() => _AnimatedGradientBackgroundState();
+}
+
+class _AnimatedGradientBackgroundState extends State<_AnimatedGradientBackground>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      vsync: this,
+      duration: const Duration(seconds: 12),
+    )..repeat(reverse: true);
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedBuilder(
+      animation: _controller,
+      builder: (context, child) {
+        final t = Curves.easeInOut.transform(_controller.value);
+        return DecoratedBox(
+          decoration: BoxDecoration(
+            gradient: LinearGradient(
+              begin: Alignment.topLeft,
+              end: Alignment.bottomRight,
+              colors: [
+                Color.lerp(const Color(0xFF1F2337), const Color(0xFF0B0D12), t)!,
+                Color.lerp(const Color(0xFF1B1F30), const Color(0xFF10142B), 1 - t)!,
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _BrandHeader extends StatelessWidget {
+  const _BrandHeader();
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      children: [
+        Column(
           crossAxisAlignment: CrossAxisAlignment.start,
-          mainAxisAlignment: MainAxisAlignment.center,
           children: [
-            Text(title, style: theme.textTheme.headlineLarge),
-            const SizedBox(height: 16),
-            Text(description, style: theme.textTheme.bodyLarge),
+            Text('Voicebook', style: theme.textTheme.headlineMedium?.copyWith(color: Colors.white)),
+            const SizedBox(height: 4),
+            Text(
+              'Голос-первый редактор',
+              style: theme.textTheme.bodyMedium?.copyWith(color: Colors.white70),
+            ),
           ],
         ),
+        const CircleAvatar(
+          radius: 24,
+          backgroundColor: Color(0x336366F1),
+          child: Icon(Icons.menu_rounded, color: Colors.white70),
+        ),
+      ],
+    );
+  }
+}
+
+class _HeroCarousel extends StatefulWidget {
+  const _HeroCarousel();
+
+  @override
+  State<_HeroCarousel> createState() => _HeroCarouselState();
+}
+
+class _HeroCarouselState extends State<_HeroCarousel> {
+  final _controller = PageController();
+  int _index = 0;
+
+  @override
+  Widget build(BuildContext context) {
+    final slides = const [
+      _BenefitSlide(
+        title: 'Диктуйте, редактируйте, экспортируйте',
+        description: 'Voicebook объединяет запись, AI-редактуру и озвучку в одном пространстве.',
       ),
+      _BenefitSlide(
+        title: 'Работает офлайн',
+        description: 'Последние главы доступны без сети, а прогресс синхронизируется позже.',
+      ),
+      _BenefitSlide(
+        title: 'Ваша студия звучания',
+        description: 'Тренируйте персональный голос и создавайте аудиокниги в один клик.',
+      ),
+    ];
+
+    return Column(
+      children: [
+        Expanded(
+          child: PageView.builder(
+            controller: _controller,
+            onPageChanged: (value) => setState(() => _index = value),
+            itemCount: slides.length,
+            itemBuilder: (context, index) => Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 8),
+              child: slides[index],
+            ),
+          ),
+        ),
+        const SizedBox(height: 16),
+        Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: List.generate(
+            slides.length,
+            (i) => AnimatedContainer(
+              duration: const Duration(milliseconds: 200),
+              margin: const EdgeInsets.symmetric(horizontal: 4),
+              height: 6,
+              width: i == _index ? 24 : 8,
+              decoration: BoxDecoration(
+                color: i == _index ? Colors.white : Colors.white24,
+                borderRadius: BorderRadius.circular(999),
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _PermissionRequestRow extends StatelessWidget {
+  const _PermissionRequestRow();
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final isWide = constraints.maxWidth > 720;
+        final cards = const [
+          _PermissionCard(
+            icon: Icons.mic_rounded,
+            title: 'Микрофон',
+            description: 'Точный захват речи и шумоподавление.',
+          ),
+          _PermissionCard(
+            icon: Icons.notifications_active,
+            title: 'Уведомления',
+            description: 'Напоминания о записях и экспортных задачах.',
+          ),
+          _PermissionCard(
+            icon: Icons.folder_outlined,
+            title: 'Файлы',
+            description: 'Хранение черновиков и экспорта офлайн.',
+          ),
+        ];
+
+        if (isWide) {
+          return Row(
+            children: cards
+                .map((card) => Expanded(
+                      child: Padding(
+                        padding: const EdgeInsets.symmetric(horizontal: 8),
+                        child: card,
+                      ),
+                    ))
+                .toList(),
+          );
+        }
+
+        return Column(
+          children: cards
+              .map((card) => Padding(
+                    padding: const EdgeInsets.symmetric(vertical: 8),
+                    child: card,
+                  ))
+              .toList(),
+        );
+      },
+    );
+  }
+}
+
+class _PermissionCard extends StatelessWidget {
+  const _PermissionCard({
+    required this.icon,
+    required this.title,
+    required this.description,
+  });
+
+  final IconData icon;
+  final String title;
+  final String description;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return GlassContainer(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          CircleAvatar(
+            radius: 24,
+            backgroundColor: Colors.white12,
+            child: Icon(icon, color: Colors.white),
+          ),
+          const SizedBox(height: 16),
+          Text(title, style: theme.textTheme.titleLarge?.copyWith(color: Colors.white)),
+          const SizedBox(height: 8),
+          Text(
+            description,
+            style: theme.textTheme.bodyMedium?.copyWith(color: Colors.white70),
+          ),
+          const SizedBox(height: 16),
+          FilledButton(
+            style: FilledButton.styleFrom(backgroundColor: Colors.white24),
+            onPressed: () {},
+            child: const Text('Разрешить'),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _LanguageSelector extends StatelessWidget {
+  const _LanguageSelector();
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final languages = const ['Русский', 'English', 'Deutsch'];
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text('Язык диктовки по умолчанию', style: theme.textTheme.titleMedium?.copyWith(color: Colors.white)),
+        const SizedBox(height: 12),
+        Wrap(
+          spacing: 12,
+          runSpacing: 12,
+          children: languages
+              .map(
+                (lang) => FilterChip(
+                  selected: lang == languages.first,
+                  onSelected: (_) {},
+                  label: Text(lang),
+                  selectedColor: Colors.white24,
+                  labelStyle: theme.textTheme.bodyMedium?.copyWith(color: Colors.white),
+                  backgroundColor: Colors.white12,
+                  side: const BorderSide(color: Colors.white24),
+                ),
+              )
+              .toList(),
+        ),
+      ],
+    );
+  }
+}
+
+class _PrimaryCta extends StatelessWidget {
+  const _PrimaryCta({required this.onPressed});
+
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return FilledButton.icon(
+      style: FilledButton.styleFrom(
+        backgroundColor: Colors.white,
+        foregroundColor: Theme.of(context).colorScheme.primary,
+        padding: const EdgeInsets.symmetric(vertical: 18, horizontal: 24),
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(999)),
+      ),
+      onPressed: onPressed,
+      icon: const Icon(Icons.play_arrow_rounded),
+      label: const Text('Начать диктовку'),
+    );
+  }
+}
+
+class GlassContainer extends StatelessWidget {
+  const GlassContainer({super.key, required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(24),
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(24),
+        color: Colors.white.withOpacity(0.08),
+        border: Border.all(color: Colors.white24),
+      ),
+      child: child,
     );
   }
 }

--- a/lib/features/settings/settings_screen.dart
+++ b/lib/features/settings/settings_screen.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../shared/ui/glass_card.dart';
+
 class SettingsScreen extends ConsumerWidget {
   const SettingsScreen({super.key});
 
@@ -10,27 +12,185 @@ class SettingsScreen extends ConsumerWidget {
       appBar: AppBar(title: const Text('Настройки')),
       body: ListView(
         padding: const EdgeInsets.all(24),
+        children: const [
+          _SectionHeader(title: 'Распознавание речи'),
+          _AsrSettings(),
+          SizedBox(height: 24),
+          _SectionHeader(title: 'AI Composer'),
+          _AiSettings(),
+          SizedBox(height: 24),
+          _SectionHeader(title: 'Озвучка'),
+          _TtsSettings(),
+          SizedBox(height: 24),
+          _SectionHeader(title: 'Синхронизация'),
+          _SyncSettings(),
+          SizedBox(height: 24),
+          _SectionHeader(title: 'Голосовые команды'),
+          _CommandsSettings(),
+        ],
+      ),
+    );
+  }
+}
+
+class _SectionHeader extends StatelessWidget {
+  const _SectionHeader({required this.title});
+
+  final String title;
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(title, style: Theme.of(context).textTheme.headlineSmall);
+  }
+}
+
+class _AsrSettings extends StatelessWidget {
+  const _AsrSettings();
+
+  @override
+  Widget build(BuildContext context) {
+    return GlassCard(
+      child: Column(
         children: [
-          Text('Распознавание речи', style: Theme.of(context).textTheme.titleLarge),
           SwitchListTile(
             value: true,
             onChanged: (_) {},
             title: const Text('Автопунктуация'),
+            subtitle: const Text('Автоматически расставляет точки и запятые'),
           ),
-          const SizedBox(height: 24),
-          Text('AI Composer', style: Theme.of(context).textTheme.titleLarge),
+          ListTile(
+            title: const Text('Язык по умолчанию'),
+            subtitle: const Text('Русский'),
+            trailing: const Icon(Icons.chevron_right),
+            onTap: () {},
+          ),
+          ListTile(
+            title: const Text('Fallback-политика'),
+            subtitle: const Text('WS → HTTP → Офлайн буфер'),
+            trailing: const Icon(Icons.chevron_right),
+            onTap: () {},
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _AiSettings extends StatelessWidget {
+  const _AiSettings();
+
+  @override
+  Widget build(BuildContext context) {
+    return GlassCard(
+      child: Column(
+        children: [
           ListTile(
             title: const Text('Провайдер'),
-            subtitle: const Text('Default'),
+            subtitle: const Text('Voicebook AI'),
             trailing: const Icon(Icons.chevron_right),
             onTap: () {},
           ),
-          const SizedBox(height: 24),
-          Text('Озвучка', style: Theme.of(context).textTheme.titleLarge),
           ListTile(
-            title: const Text('Голос по умолчанию'),
+            title: const Text('Лимит токенов в день'),
+            subtitle: const Text('Осталось 8 500'),
             trailing: const Icon(Icons.chevron_right),
             onTap: () {},
+          ),
+          ListTile(
+            title: const Text('Пресет стиля по умолчанию'),
+            subtitle: const Text('Научно-популярный'),
+            trailing: const Icon(Icons.chevron_right),
+            onTap: () {},
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _TtsSettings extends StatelessWidget {
+  const _TtsSettings();
+
+  @override
+  Widget build(BuildContext context) {
+    return GlassCard(
+      child: Column(
+        children: [
+          SwitchListTile(
+            value: true,
+            onChanged: (_) {},
+            title: const Text('Использовать персональный голос'),
+            subtitle: const Text('Недоступно без завершения тренировки'),
+          ),
+          ListTile(
+            title: const Text('Голос по умолчанию'),
+            subtitle: const Text('Night Station v2'),
+            trailing: const Icon(Icons.chevron_right),
+            onTap: () {},
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SyncSettings extends StatelessWidget {
+  const _SyncSettings();
+
+  @override
+  Widget build(BuildContext context) {
+    return GlassCard(
+      child: Column(
+        children: [
+          RadioListTile<String>(
+            value: 'local',
+            groupValue: 'cloud',
+            onChanged: (_) {},
+            title: const Text('Только локально'),
+            subtitle: const Text('Данные остаются на устройстве'),
+          ),
+          RadioListTile<String>(
+            value: 'cloud',
+            groupValue: 'cloud',
+            onChanged: (_) {},
+            title: const Text('С облачной синхронизацией'),
+            subtitle: const Text('Резервное копирование и доступ с других устройств'),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _CommandsSettings extends StatelessWidget {
+  const _CommandsSettings();
+
+  @override
+  Widget build(BuildContext context) {
+    final commands = ['"Новая глава"', '"Начать запись"', '"Перефразируй абзац"'];
+    return GlassCard(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          SwitchListTile(
+            value: true,
+            onChanged: (_) {},
+            title: const Text('Включить голосовые команды'),
+          ),
+          const Divider(),
+          ...commands.map(
+            (command) => ListTile(
+              leading: const Icon(Icons.record_voice_over),
+              title: Text(command),
+              trailing: const Icon(Icons.edit_outlined),
+              onTap: () {},
+            ),
+          ),
+          const SizedBox(height: 12),
+          OutlinedButton.icon(
+            onPressed: () {},
+            icon: const Icon(Icons.add),
+            label: const Text('Добавить команду'),
           ),
         ],
       ),

--- a/lib/features/structure_mindmap/structure_mindmap_screen.dart
+++ b/lib/features/structure_mindmap/structure_mindmap_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+
 import '../../core/models/models.dart';
 import '../../shared/ui/glass_card.dart';
 
@@ -12,27 +13,97 @@ class StructureMindmapScreen extends StatelessWidget {
     return Dialog(
       insetPadding: const EdgeInsets.all(32),
       child: GlassCard(
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Text('Структура главы', style: Theme.of(context).textTheme.headlineMedium),
-            const SizedBox(height: 16),
-            Expanded(
-              child: ListView(
-                padding: EdgeInsets.zero,
-                children:
-                    nodes.map((node) => _StructureNode(node: node)).toList(),
+        padding: const EdgeInsets.all(32),
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 860, maxHeight: 640),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Row(
+                children: [
+                  Text('Структура главы', style: Theme.of(context).textTheme.headlineMedium),
+                  const Spacer(),
+                  IconButton(onPressed: () {}, icon: const Icon(Icons.help_outline)),
+                ],
               ),
-            ),
-          ],
+              const SizedBox(height: 16),
+              TextField(
+                decoration: InputDecoration(
+                  prefixIcon: const Icon(Icons.search),
+                  hintText: 'Поиск по сценам',
+                  filled: true,
+                  fillColor: Theme.of(context).colorScheme.surfaceVariant.withOpacity(0.6),
+                  border: OutlineInputBorder(borderRadius: BorderRadius.circular(16), borderSide: BorderSide.none),
+                ),
+              ),
+              const SizedBox(height: 16),
+              Wrap(
+                spacing: 12,
+                runSpacing: 12,
+                children: [
+                  FilledButton.icon(
+                    onPressed: () {},
+                    icon: const Icon(Icons.add),
+                    label: const Text('Добавить сцену'),
+                  ),
+                  OutlinedButton.icon(
+                    onPressed: () {},
+                    icon: const Icon(Icons.account_tree_outlined),
+                    label: const Text('Развернуть все'),
+                  ),
+                  OutlinedButton.icon(
+                    onPressed: () {},
+                    icon: const Icon(Icons.undo),
+                    label: const Text('Отменить'),
+                  ),
+                  OutlinedButton.icon(
+                    onPressed: () {},
+                    icon: const Icon(Icons.redo),
+                    label: const Text('Повторить'),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 24),
+              Expanded(
+                child: ClipRRect(
+                  borderRadius: BorderRadius.circular(16),
+                  child: ListView(
+                    children: nodes
+                        .map(
+                          (node) => _MindmapNode(
+                            node: node,
+                            depth: 0,
+                          ),
+                        )
+                        .toList(),
+                  ),
+                ),
+              ),
+              const SizedBox(height: 16),
+              Row(
+                children: [
+                  FilledButton.icon(
+                    onPressed: () => Navigator.of(context).pop(),
+                    icon: const Icon(Icons.check),
+                    label: const Text('Вставить якоря'),
+                  ),
+                  const SizedBox(width: 12),
+                  TextButton(
+                    onPressed: () => Navigator.of(context).pop(),
+                    child: const Text('Закрыть'),
+                  ),
+                ],
+              ),
+            ],
+          ),
         ),
       ),
     );
   }
 }
 
-class _StructureNode extends StatelessWidget {
-  const _StructureNode({required this.node, this.depth = 0});
+class _MindmapNode extends StatelessWidget {
+  const _MindmapNode({required this.node, required this.depth});
 
   final SceneNode node;
   final int depth;
@@ -40,41 +111,45 @@ class _StructureNode extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final children = <Widget>[
-      Padding(
-        padding: EdgeInsets.only(left: depth * 16.0, top: 4, bottom: 4),
-        child: Row(
+    final isLeaf = node.children.isEmpty;
+    return Card(
+      margin: EdgeInsets.only(left: depth * 24.0, right: 16, bottom: 12),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+        child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Icon(Icons.circle, size: 8, color: theme.colorScheme.primary),
-            const SizedBox(width: 8),
-            Expanded(
-              child: Text(
-                node.title,
-                style: theme.textTheme.bodyLarge,
-              ),
+            Row(
+              children: [
+                Icon(isLeaf ? Icons.note_outlined : Icons.fork_right, color: theme.colorScheme.primary),
+                const SizedBox(width: 12),
+                Expanded(child: Text(node.title, style: theme.textTheme.titleMedium)),
+                PopupMenuButton<String>(
+                  itemBuilder: (context) => const [
+                    PopupMenuItem(value: 'add', child: Text('Добавить дочернюю сцену')),
+                    PopupMenuItem(value: 'rename', child: Text('Переименовать')),
+                    PopupMenuItem(value: 'delete', child: Text('Удалить')),
+                  ],
+                ),
+              ],
             ),
+            if (node.children.isNotEmpty) ...[
+              const SizedBox(height: 12),
+              Column(
+                children: node.children
+                    .map(
+                      (child) => _MindmapNode(
+                        node: child,
+                        depth: depth + 1,
+                      ),
+                    )
+                    .toList(),
+              ),
+            ],
           ],
         ),
       ),
-    ];
-
-    if (node.children.isNotEmpty) {
-      children.addAll(
-        node.children
-            .map(
-              (child) => _StructureNode(
-                node: child,
-                depth: depth + 1,
-              ),
-            )
-            .toList(),
-      );
-    }
-
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.stretch,
-      children: children,
     );
   }
 }

--- a/lib/features/voice_training/voice_training_screen.dart
+++ b/lib/features/voice_training/voice_training_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:math' as math;
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -8,27 +10,244 @@ class VoiceTrainingScreen extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final phrases = List.generate(5, (index) => 'Фраза ${index + 1}: Голос ночной станции слышен каждому.');
+
     return Scaffold(
       appBar: AppBar(title: const Text('Тренировка голоса')),
       body: Padding(
         padding: const EdgeInsets.all(24),
-        child: GlassCard(
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text('Запишите несколько фраз', style: Theme.of(context).textTheme.headlineMedium),
-              const SizedBox(height: 16),
-              const Text('Озвучка станет доступна после завершения анализа качества.'),
-              const SizedBox(height: 24),
-              FilledButton.icon(
-                onPressed: () {},
-                icon: const Icon(Icons.mic),
-                label: const Text('Записать фразу'),
+        child: Row(
+          children: [
+            Expanded(
+              flex: 2,
+              child: GlassCard(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text('Запишите 5 коротких фраз', style: Theme.of(context).textTheme.headlineSmall),
+                    const SizedBox(height: 12),
+                    const Text('Каждая фраза должна быть озвучена в тихом помещении. Мы проанализируем качество и сообщим результат.'),
+                    const SizedBox(height: 24),
+                    Expanded(
+                      child: ListView.separated(
+                        itemCount: phrases.length,
+                        separatorBuilder: (_, __) => const SizedBox(height: 12),
+                        itemBuilder: (context, index) {
+                          final completed = index < 2;
+                          return _PhraseTile(
+                            text: phrases[index],
+                            completed: completed,
+                            snr: completed ? 23 + index * 2 : null,
+                          );
+                        },
+                      ),
+                    ),
+                    const SizedBox(height: 16),
+                    Row(
+                      children: const [
+                        Icon(Icons.info_outline, color: Colors.white70),
+                        SizedBox(width: 8),
+                        Expanded(child: Text('Качественные сэмплы ускоряют генерацию персонального голоса.')),
+                      ],
+                    ),
+                  ],
+                ),
               ),
-            ],
-          ),
+            ),
+            const SizedBox(width: 24),
+            Expanded(
+              child: Column(
+                children: [
+                  Expanded(
+                    child: GlassCard(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text('Запись', style: Theme.of(context).textTheme.headlineSmall),
+                          const SizedBox(height: 12),
+                          const Text('Нажмите и удерживайте кнопку, проговорите фразу медленно и чётко.'),
+                          const SizedBox(height: 24),
+                          const _RecordingPanel(),
+                          const SizedBox(height: 24),
+                          _QualityMeter(value: 0.72),
+                          const SizedBox(height: 24),
+                          Row(
+                            children: [
+                              Checkbox(value: true, onChanged: (_) {}),
+                              const Expanded(child: Text('Я соглашаюсь использовать свой голос для синтеза и маркировки «Синтетическая озвучка».')),
+                            ],
+                          ),
+                          const SizedBox(height: 12),
+                          FilledButton.icon(
+                            onPressed: () {},
+                            icon: const Icon(Icons.school_outlined),
+                            label: const Text('Отправить на анализ'),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: 24),
+                  GlassCard(
+                    child: Row(
+                      children: const [
+                        Icon(Icons.shield_outlined),
+                        SizedBox(width: 12),
+                        Expanded(
+                          child: Text('Статус профиля: training → ожидает проверки. Получите уведомление, когда голос будет готов.'),
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
         ),
       ),
+    );
+  }
+}
+
+class _PhraseTile extends StatelessWidget {
+  const _PhraseTile({required this.text, required this.completed, this.snr});
+
+  final String text;
+  final bool completed;
+  final int? snr;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return ListTile(
+      tileColor: theme.colorScheme.surfaceVariant.withOpacity(0.3),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+      leading: Icon(completed ? Icons.check_circle : Icons.radio_button_unchecked,
+          color: completed ? Colors.greenAccent : theme.colorScheme.primary),
+      title: Text(text),
+      subtitle: completed && snr != null ? Text('SNR: $snr дБ — отлично') : const Text('Ожидает записи'),
+      trailing: FilledButton.tonalIcon(
+        onPressed: () {},
+        icon: const Icon(Icons.mic),
+        label: const Text('Записать'),
+      ),
+    );
+  }
+}
+
+class _RecordingPanel extends StatefulWidget {
+  const _RecordingPanel();
+
+  @override
+  State<_RecordingPanel> createState() => _RecordingPanelState();
+}
+
+class _RecordingPanelState extends State<_RecordingPanel> with SingleTickerProviderStateMixin {
+  late final AnimationController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(vsync: this, duration: const Duration(milliseconds: 1500))..repeat();
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedBuilder(
+      animation: _controller,
+      builder: (context, child) {
+        final level = (math.sin(_controller.value * math.pi * 2) + 1) / 2;
+        return Column(
+          children: [
+            Container(
+              height: 120,
+              decoration: BoxDecoration(
+                borderRadius: BorderRadius.circular(24),
+                gradient: LinearGradient(
+                  colors: [Colors.pinkAccent.withOpacity(0.4), Colors.deepPurpleAccent.withOpacity(0.2)],
+                ),
+              ),
+              child: CustomPaint(
+                painter: _WavePainter(level: level),
+              ),
+            ),
+            const SizedBox(height: 20),
+            ElevatedButton.icon(
+              onPressed: () {},
+              icon: const Icon(Icons.mic),
+              label: const Text('Запись идёт... 00:32'),
+              style: ElevatedButton.styleFrom(
+                backgroundColor: Colors.pinkAccent,
+                foregroundColor: Colors.white,
+                padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 14),
+                shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(24)),
+              ),
+            ),
+          ],
+        );
+      },
+    );
+  }
+}
+
+class _WavePainter extends CustomPainter {
+  const _WavePainter({required this.level});
+
+  final double level;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final paint = Paint()
+      ..color = Colors.white
+      ..strokeWidth = 2
+      ..style = PaintingStyle.stroke;
+    final path = Path();
+    for (double x = 0; x <= size.width; x += 12) {
+      final y = size.height / 2 + math.sin((x / size.width * 2 * math.pi) + level * math.pi) * 28 * (0.4 + level * 0.6);
+      if (x == 0) {
+        path.moveTo(x, y);
+      } else {
+        path.lineTo(x, y);
+      }
+    }
+    canvas.drawPath(path, paint);
+  }
+
+  @override
+  bool shouldRepaint(covariant _WavePainter oldDelegate) => oldDelegate.level != level;
+}
+
+class _QualityMeter extends StatelessWidget {
+  const _QualityMeter({required this.value});
+
+  final double value;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text('Качество записи', style: theme.textTheme.titleMedium),
+        const SizedBox(height: 8),
+        ClipRRect(
+          borderRadius: BorderRadius.circular(999),
+          child: LinearProgressIndicator(
+            value: value,
+            minHeight: 12,
+            backgroundColor: theme.colorScheme.surfaceVariant,
+            valueColor: const AlwaysStoppedAnimation(Colors.greenAccent),
+          ),
+        ),
+        const SizedBox(height: 8),
+        Text('SNR 22 дБ · Шумы 8%', style: theme.textTheme.bodySmall),
+      ],
     );
   }
 }

--- a/lib/shared/ui/glass_search_field.dart
+++ b/lib/shared/ui/glass_search_field.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+
+import '../tokens/design_tokens.dart';
+
+class GlassSearchField extends StatelessWidget {
+  const GlassSearchField({
+    super.key,
+    this.hintText = 'Поиск',
+    this.onChanged,
+  });
+
+  final String hintText;
+  final ValueChanged<String>? onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(AppSpacing.radiusLarge),
+        color: Colors.white.withOpacity(0.08),
+        border: Border.all(color: Colors.white.withOpacity(0.12)),
+      ),
+      padding: const EdgeInsets.symmetric(horizontal: 20),
+      child: Row(
+        children: [
+          Icon(Icons.search_rounded, color: theme.colorScheme.onSurface.withOpacity(0.6)),
+          const SizedBox(width: 12),
+          Expanded(
+            child: TextField(
+              onChanged: onChanged,
+              style: theme.textTheme.bodyLarge,
+              decoration: InputDecoration(
+                hintText: hintText,
+                border: InputBorder.none,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- redesign onboarding with animated hero carousel, permission prompts, and language selector
- build library grid, glass search, and neon notebook cards to match the Calm Neon style
- flesh out book workspace, AI composer, mindmap, voice training, export, and settings surfaces with detailed widgets and demo data

## Testing
- flutter analyze *(fails: tool not available in container)*

------
https://chatgpt.com/codex/tasks/task_b_68d7039641b483228db97cd14318653c