### PR TITLE
Fix build errors against Flutter 3.22 and flutter_quill 11.4.2

### DIFF
--- a/lib/features/ai_composer/ai_composer_drawer.dart
+++ b/lib/features/ai_composer/ai_composer_drawer.dart
@@ -91,7 +91,7 @@ class _AiComposerDrawerState extends State<AiComposerDrawer> {
                   ),
                   FilledButton.icon(
                     onPressed: () {},
-                    icon: const Icon(Icons.sparkles),
+                    icon: const Icon(Icons.auto_awesome_outlined),
                     label: const Text('Сделать художественнее'),
                   ),
                 ],

--- a/lib/features/book_workspace/widgets/editor/chapter_editor.dart
+++ b/lib/features/book_workspace/widgets/editor/chapter_editor.dart
@@ -154,7 +154,7 @@ class _ChapterEditorState extends State<ChapterEditor> {
                         controller: _controller,
                         focusNode: _editorFocusNode,
                         scrollController: _scrollController,
-                        configurations: const quill.QuillEditorConfigurations(
+                        config: const quill.QuillEditorConfig(
                           expands: true,
                           placeholder: 'Начните диктовать или печатать...',
                         ),

--- a/lib/features/library/widgets/notebook_card.dart
+++ b/lib/features/library/widgets/notebook_card.dart
@@ -68,10 +68,10 @@ class NotebookCard extends StatelessWidget {
                     spacing: 8,
                     runSpacing: 8,
                     children: [
-                      _TagChip(label: '${notebook.chapters} глав'),
-                      _TagChip(label: '${notebook.words ~/ 1000} тыс. слов'),
+                      _TagChip('${notebook.chapters} глав'),
+                      _TagChip('${notebook.words ~/ 1000} тыс. слов'),
                       if (notebook.audioMinutes > 0)
-                        _TagChip(label: '${notebook.audioMinutes.round()} мин аудио'),
+                        _TagChip('${notebook.audioMinutes.round()} мин аудио'),
                       ...notebook.tags.map(_TagChip.new),
                     ],
                   ),


### PR DESCRIPTION
## Summary
- update the AI composer action to use an icon available in the current Flutter stable channel
- migrate the chapter editor to flutter_quill's new `QuillEditorConfig` API
- fix notebook tag chips to call the positional constructor consistently

## Testing
- not run (flutter is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_b_68d705ffd5208322b07ffc21e487ea10