### PR TITLE
Fix web URL strategy initialization

### DIFF
--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -1,7 +1,5 @@
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:flutter_web_plugins/url_strategy.dart';
 import 'package:go_router/go_router.dart';
 
 import '../core/providers/app_providers.dart';
@@ -17,10 +15,6 @@ import '../features/voice_training/voice_training_screen.dart';
 final _rootNavigatorKey = GlobalKey<NavigatorState>(debugLabel: 'root');
 
 final appRouterProvider = Provider<GoRouter>((ref) {
-  if (kIsWeb) {
-    setUrlStrategy(PathUrlStrategy());
-  }
-
   final permissions = ref.watch(permissionsProvider);
 
   return GoRouter(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,10 +1,15 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_web_plugins/url_strategy.dart';
 
 import 'app/app.dart';
 
 void main() {
   WidgetsFlutterBinding.ensureInitialized();
+  if (kIsWeb) {
+    setUrlStrategy(PathUrlStrategy());
+  }
   runApp(const ProviderScope(child: VoicebookApp()));
 }


### PR DESCRIPTION
## Summary
- move the web URL strategy setup into `main.dart` so it runs only once
- remove duplicate URL strategy configuration from the router provider to prevent assertion failures

## Testing
- flutter test *(fails: Flutter is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_b_68d70f0453dc8322bc5faece552a0df0