### PR TITLE
Fix incorrect Expanded nesting in book workspace layout

### DIFF
--- a/lib/features/book_workspace/book_workspace_screen.dart
+++ b/lib/features/book_workspace/book_workspace_screen.dart
@@ -58,11 +58,9 @@ class BookWorkspaceScreen extends ConsumerWidget {
           ),
         );
 
-        final editor = Expanded(
-          child: Padding(
-            padding: const EdgeInsets.symmetric(horizontal: AppSpacing.gutter),
-            child: ChapterEditor(chapter: chapter),
-          ),
+        final editor = Padding(
+          padding: const EdgeInsets.symmetric(horizontal: AppSpacing.gutter),
+          child: ChapterEditor(chapter: chapter),
         );
 
         final fabPanel = Align(
@@ -125,7 +123,7 @@ class BookWorkspaceScreen extends ConsumerWidget {
                 crossAxisAlignment: CrossAxisAlignment.stretch,
                 children: [
                   ruler,
-                  editor,
+                  Expanded(child: editor),
                   Expanded(
                     child: Stack(
                       children: [


### PR DESCRIPTION
## Summary
- stop wrapping the editor panel in nested Expanded widgets in the book workspace screen
- ensure desktop and mobile layouts expand the editor once while preserving padding

## Testing
- Not run (Flutter SDK is unavailable in the environment)

------
https://chatgpt.com/codex/tasks/task_b_68d71002053c8322b89614e2fe18d927