### PR TITLE
Implement local storage sync and dictation flows

### DIFF
--- a/lib/core/api/voicebook_api_service.dart
+++ b/lib/core/api/voicebook_api_service.dart
@@ -25,6 +25,21 @@ abstract class VoicebookApiService {
 
   /// Returns the current voice profile that will be used for TTS preview.
   Future<VoiceProfile> getVoiceProfile();
+
+  /// Returns application settings for the provided user.
+  Future<AppSettings> getSettings(String userId);
+
+  /// Persists the provided notebook snapshot.
+  Future<void> syncNotebook(Notebook notebook);
+
+  /// Persists the provided chapters snapshot for the notebook.
+  Future<void> syncChapters(String notebookId, List<Chapter> chapters);
+
+  /// Updates the settings for the given user identifier.
+  Future<void> syncSettings(String userId, AppSettings settings);
+
+  /// Updates the voice profile metadata.
+  Future<void> syncVoiceProfile(VoiceProfile profile);
 }
 
 /// In-memory mock that emulates the behaviour of the real API.
@@ -33,10 +48,21 @@ abstract class VoicebookApiService {
 /// call returns a [Future] and mimics a small network delay. This allows the UI
 /// to exercise loading states and makes switching to the real backend trivial.
 class MockVoicebookApiService implements VoicebookApiService {
-  const MockVoicebookApiService({this.latency = const Duration(milliseconds: 120)});
+  MockVoicebookApiService({this.latency = const Duration(milliseconds: 120)})
+      : _notebooks = List<Notebook>.from(mockNotebooks),
+        _chapterMap = {
+          for (final entry in mockChapterMap.entries)
+            entry.key: List<Chapter>.from(entry.value),
+        },
+        _voiceProfile = mockVoiceProfile,
+        _settingsByUser = {};
 
   /// Artificial latency that imitates a roundtrip to the backend.
   final Duration latency;
+  final List<Notebook> _notebooks;
+  final Map<String, List<Chapter>> _chapterMap;
+  VoiceProfile _voiceProfile;
+  final Map<String, AppSettings> _settingsByUser;
 
   Future<T> _withLatency<T>(T Function() builder) {
     return Future<T>.delayed(latency, builder);
@@ -44,13 +70,13 @@ class MockVoicebookApiService implements VoicebookApiService {
 
   @override
   Future<List<Notebook>> getNotebooks() {
-    return _withLatency(() => List.unmodifiable(mockNotebooks));
+    return _withLatency(() => List.unmodifiable(_notebooks));
   }
 
   @override
   Future<Notebook?> getNotebook(String notebookId) {
     return _withLatency(() {
-      for (final notebook in mockNotebooks) {
+      for (final notebook in _notebooks) {
         if (notebook.id == notebookId) {
           return notebook;
         }
@@ -62,14 +88,14 @@ class MockVoicebookApiService implements VoicebookApiService {
   @override
   Future<List<Chapter>> getChapters(String notebookId) {
     return _withLatency(
-      () => List.unmodifiable(mockChapterMap[notebookId] ?? const <Chapter>[]),
+      () => List.unmodifiable(_chapterMap[notebookId] ?? const <Chapter>[]),
     );
   }
 
   @override
   Future<Chapter?> getChapter(String notebookId, String chapterId) {
     return _withLatency(() {
-      final chapters = mockChapterMap[notebookId];
+      final chapters = _chapterMap[notebookId];
       if (chapters == null) {
         return null;
       }
@@ -84,6 +110,44 @@ class MockVoicebookApiService implements VoicebookApiService {
 
   @override
   Future<VoiceProfile> getVoiceProfile() {
-    return _withLatency(() => mockVoiceProfile);
+    return _withLatency(() => _voiceProfile);
+  }
+
+  @override
+  Future<AppSettings> getSettings(String userId) {
+    return _withLatency(() => _settingsByUser[userId] ?? mockAppSettings);
+  }
+
+  @override
+  Future<void> syncNotebook(Notebook notebook) {
+    return _withLatency(() {
+      final index = _notebooks.indexWhere((item) => item.id == notebook.id);
+      if (index >= 0) {
+        _notebooks[index] = notebook;
+      } else {
+        _notebooks.add(notebook);
+      }
+    });
+  }
+
+  @override
+  Future<void> syncChapters(String notebookId, List<Chapter> chapters) {
+    return _withLatency(() {
+      _chapterMap[notebookId] = List<Chapter>.from(chapters);
+    });
+  }
+
+  @override
+  Future<void> syncSettings(String userId, AppSettings settings) {
+    return _withLatency(() {
+      _settingsByUser[userId] = settings;
+    });
+  }
+
+  @override
+  Future<void> syncVoiceProfile(VoiceProfile profile) {
+    return _withLatency(() {
+      _voiceProfile = profile;
+    });
   }
 }

--- a/lib/core/mock/mock_data.dart
+++ b/lib/core/mock/mock_data.dart
@@ -61,6 +61,8 @@ final mockChapterMap = <String, List<Chapter>>{
           ],
         ),
       ],
+      body:
+          'Станция дышала приглушённым гулом серверов, когда Ина сделала первую запись. Она стояла у микрофона и вслушивалась в туман, пытаясь понять, чей голос спрятан в шорохах эфира.',
     ),
     Chapter(
       id: 'ch-1',
@@ -90,6 +92,8 @@ final mockChapterMap = <String, List<Chapter>>{
           ],
         ),
       ],
+      body:
+          'Туман повис над станцией так плотно, будто сам эфир решил стать стеной. Алекс проверял уровни сигнала, а Ина вслушивалась в шёпоты, которые записались ночью. В них слышалась просьба о помощи.',
     ),
     Chapter(
       id: 'ch-2',
@@ -112,6 +116,8 @@ final mockChapterMap = <String, List<Chapter>>{
           ],
         ),
       ],
+      body:
+          'В архиве запахло озоном и пылью. Стеллажи с плёнками уходили в темноту, а на мониторе оживали забытые голоса. Ина нашла старую кассету и включила её — из динамиков раздался голос, который она слышала в тумане.',
     ),
   ],
   'book-speech-guide': [
@@ -130,6 +136,8 @@ final mockChapterMap = <String, List<Chapter>>{
         SceneNode(id: 'guide-scene-1', title: 'Дыхательная гимнастика'),
         SceneNode(id: 'guide-scene-2', title: 'Артикуляционная зарядка'),
       ],
+      body:
+          'Перед записью прогрейте голос: сделайте три глубоких вдоха, растягивайте губы и язык. Представьте, что каждое слово — это луч света, который вы направляете в микрофон.',
     ),
     Chapter(
       id: 'guide-ch-2',
@@ -146,6 +154,8 @@ final mockChapterMap = <String, List<Chapter>>{
         SceneNode(id: 'guide-scene-3', title: 'Где делать паузы'),
         SceneNode(id: 'guide-scene-4', title: 'Упражнение «Метроном»'),
       ],
+      body:
+          'Паузы — главный инструмент темпа. Представьте метроном и говорите под его такт. Делайте короткие остановки перед важными словами, чтобы слушатель успел представить картину.',
     ),
   ],
   'book-travel-notes': [
@@ -164,6 +174,8 @@ final mockChapterMap = <String, List<Chapter>>{
         SceneNode(id: 'travel-scene-1', title: 'Раннее утро'),
         SceneNode(id: 'travel-scene-2', title: 'Базар и специи'),
       ],
+      body:
+          'Утро в оазисе начиналось с запаха шафрана. Торговцы раскладывали ткани, а я записывал истории путников. Их голоса становились заметками, которые позже сложились в эту главу.',
     ),
   ],
 };
@@ -175,4 +187,18 @@ final mockVoiceProfile = VoiceProfile(
   locale: 'ru-RU',
   status: VoiceProfileStatus.training,
   isConsentGiven: true,
+);
+
+final mockAppSettings = AppSettings(
+  autoPunctuation: true,
+  defaultLanguage: 'ru-RU',
+  fallbackPolicy: 'WS → HTTP → Offline буфер',
+  aiProvider: 'Voicebook AI',
+  dailyTokenLimit: 12000,
+  defaultAiPreset: 'Научно-популярный',
+  usePersonalVoice: false,
+  defaultVoice: 'Night Station v2',
+  syncStrategy: 'cloud',
+  voiceCommandsEnabled: true,
+  voiceCommands: const ['"Новая глава"', '"Начать запись"', '"Перефразируй абзац"'],
 );

--- a/lib/core/models/app_settings.dart
+++ b/lib/core/models/app_settings.dart
@@ -1,0 +1,107 @@
+import 'package:equatable/equatable.dart';
+
+class AppSettings extends Equatable {
+  const AppSettings({
+    required this.autoPunctuation,
+    required this.defaultLanguage,
+    required this.fallbackPolicy,
+    required this.aiProvider,
+    required this.dailyTokenLimit,
+    required this.defaultAiPreset,
+    required this.usePersonalVoice,
+    required this.defaultVoice,
+    required this.syncStrategy,
+    required this.voiceCommandsEnabled,
+    required this.voiceCommands,
+  });
+
+  final bool autoPunctuation;
+  final String defaultLanguage;
+  final String fallbackPolicy;
+  final String aiProvider;
+  final int dailyTokenLimit;
+  final String defaultAiPreset;
+  final bool usePersonalVoice;
+  final String defaultVoice;
+  final String syncStrategy;
+  final bool voiceCommandsEnabled;
+  final List<String> voiceCommands;
+
+  AppSettings copyWith({
+    bool? autoPunctuation,
+    String? defaultLanguage,
+    String? fallbackPolicy,
+    String? aiProvider,
+    int? dailyTokenLimit,
+    String? defaultAiPreset,
+    bool? usePersonalVoice,
+    String? defaultVoice,
+    String? syncStrategy,
+    bool? voiceCommandsEnabled,
+    List<String>? voiceCommands,
+  }) {
+    return AppSettings(
+      autoPunctuation: autoPunctuation ?? this.autoPunctuation,
+      defaultLanguage: defaultLanguage ?? this.defaultLanguage,
+      fallbackPolicy: fallbackPolicy ?? this.fallbackPolicy,
+      aiProvider: aiProvider ?? this.aiProvider,
+      dailyTokenLimit: dailyTokenLimit ?? this.dailyTokenLimit,
+      defaultAiPreset: defaultAiPreset ?? this.defaultAiPreset,
+      usePersonalVoice: usePersonalVoice ?? this.usePersonalVoice,
+      defaultVoice: defaultVoice ?? this.defaultVoice,
+      syncStrategy: syncStrategy ?? this.syncStrategy,
+      voiceCommandsEnabled: voiceCommandsEnabled ?? this.voiceCommandsEnabled,
+      voiceCommands: voiceCommands ?? this.voiceCommands,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'autoPunctuation': autoPunctuation,
+      'defaultLanguage': defaultLanguage,
+      'fallbackPolicy': fallbackPolicy,
+      'aiProvider': aiProvider,
+      'dailyTokenLimit': dailyTokenLimit,
+      'defaultAiPreset': defaultAiPreset,
+      'usePersonalVoice': usePersonalVoice,
+      'defaultVoice': defaultVoice,
+      'syncStrategy': syncStrategy,
+      'voiceCommandsEnabled': voiceCommandsEnabled,
+      'voiceCommands': voiceCommands,
+    };
+  }
+
+  factory AppSettings.fromJson(Map<String, dynamic> json) {
+    return AppSettings(
+      autoPunctuation: json['autoPunctuation'] as bool? ?? true,
+      defaultLanguage: json['defaultLanguage'] as String? ?? 'ru-RU',
+      fallbackPolicy: json['fallbackPolicy'] as String? ?? 'WS→HTTP→OFFLINE',
+      aiProvider: json['aiProvider'] as String? ?? 'Voicebook AI',
+      dailyTokenLimit: json['dailyTokenLimit'] as int? ?? 0,
+      defaultAiPreset: json['defaultAiPreset'] as String? ?? 'Художественный',
+      usePersonalVoice: json['usePersonalVoice'] as bool? ?? false,
+      defaultVoice: json['defaultVoice'] as String? ?? 'Night Station v2',
+      syncStrategy: json['syncStrategy'] as String? ?? 'cloud',
+      voiceCommandsEnabled: json['voiceCommandsEnabled'] as bool? ?? true,
+      voiceCommands: [
+        for (final value in (json['voiceCommands'] as List<dynamic>? ?? const []))
+          value as String,
+      ],
+    );
+  }
+
+  @override
+  List<Object?> get props => [
+        autoPunctuation,
+        defaultLanguage,
+        fallbackPolicy,
+        aiProvider,
+        dailyTokenLimit,
+        defaultAiPreset,
+        usePersonalVoice,
+        defaultVoice,
+        syncStrategy,
+        voiceCommandsEnabled,
+        voiceCommands,
+      ];
+}

--- a/lib/core/models/chapter.dart
+++ b/lib/core/models/chapter.dart
@@ -18,6 +18,7 @@ class Chapter extends Equatable {
     this.meta = const {},
     this.structure = const [],
     this.blocks = const [],
+    this.body = '',
   });
 
   final ID id;
@@ -28,6 +29,48 @@ class Chapter extends Equatable {
   final Map<String, String?> meta;
   final List<SceneNode> structure;
   final List<RichBlock> blocks;
+  final String body;
+
+  factory Chapter.fromJson(Map<String, dynamic> json) {
+    final statusValue = json['status'] as String?;
+    final blocks = (json['blocks'] as List<dynamic>? ?? const [])
+        .map((value) => RichBlock.fromJson(Map<String, dynamic>.from(value as Map)))
+        .toList();
+    return Chapter(
+      id: json['id'] as String,
+      bookId: json['bookId'] as String,
+      title: json['title'] as String? ?? '',
+      subtitle: json['subtitle'] as String?,
+      status: ChapterStatus.values.firstWhere(
+        (status) => status.name == statusValue,
+        orElse: () => ChapterStatus.draft,
+      ),
+      meta: {
+        for (final entry in (json['meta'] as Map<String, dynamic>? ?? const {}))
+          entry.key: entry.value as String?,
+      },
+      structure: [
+        for (final node in (json['structure'] as List<dynamic>? ?? const []))
+          SceneNode.fromJson(Map<String, dynamic>.from(node as Map)),
+      ],
+      blocks: blocks,
+      body: json['body'] as String? ?? blocks.map((block) => block.text).join('\n\n'),
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'bookId': bookId,
+      'title': title,
+      'subtitle': subtitle,
+      'status': status.name,
+      'meta': meta,
+      'structure': [for (final node in structure) node.toJson()],
+      'blocks': [for (final block in blocks) block.toJson()],
+      'body': body,
+    };
+  }
 
   Chapter copyWith({
     String? title,
@@ -36,6 +79,7 @@ class Chapter extends Equatable {
     Map<String, String?>? meta,
     List<SceneNode>? structure,
     List<RichBlock>? blocks,
+    String? body,
   }) {
     return Chapter(
       id: id,
@@ -46,6 +90,7 @@ class Chapter extends Equatable {
       meta: meta ?? this.meta,
       structure: structure ?? this.structure,
       blocks: blocks ?? this.blocks,
+      body: body ?? this.body,
     );
   }
 
@@ -59,5 +104,6 @@ class Chapter extends Equatable {
         meta,
         structure,
         blocks,
+        body,
       ];
 }

--- a/lib/core/models/models.dart
+++ b/lib/core/models/models.dart
@@ -1,4 +1,5 @@
 export 'asr_session.dart';
+export 'app_settings.dart';
 export 'chapter.dart';
 export 'chapter_summary.dart';
 export 'ids.dart';

--- a/lib/core/models/notebook.dart
+++ b/lib/core/models/notebook.dart
@@ -23,6 +23,35 @@ class Notebook extends Equatable {
   final int words;
   final double audioMinutes;
 
+  factory Notebook.fromJson(Map<String, dynamic> json) {
+    return Notebook(
+      id: json['id'] as String,
+      title: json['title'] as String? ?? '',
+      coverUrl: json['coverUrl'] as String?,
+      tags: [
+        for (final tag in (json['tags'] as List<dynamic>? ?? const []))
+          tag as String,
+      ],
+      updatedAt: DateTime.tryParse(json['updatedAt'] as String? ?? '') ?? DateTime.now(),
+      chapters: json['chapters'] as int? ?? 0,
+      words: json['words'] as int? ?? 0,
+      audioMinutes: (json['audioMinutes'] as num?)?.toDouble() ?? 0,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'title': title,
+      'coverUrl': coverUrl,
+      'tags': tags,
+      'updatedAt': updatedAt.toIso8601String(),
+      'chapters': chapters,
+      'words': words,
+      'audioMinutes': audioMinutes,
+    };
+  }
+
   Notebook copyWith({
     String? title,
     String? coverUrl,

--- a/lib/core/models/rich_block.dart
+++ b/lib/core/models/rich_block.dart
@@ -16,6 +16,30 @@ class RichBlock extends Equatable {
   final String text;
   final List<String> marks;
 
+  factory RichBlock.fromJson(Map<String, dynamic> json) {
+    return RichBlock(
+      id: json['id'] as String,
+      type: RichBlockType.values.firstWhere(
+        (value) => value.name == json['type'],
+        orElse: () => RichBlockType.paragraph,
+      ),
+      text: json['text'] as String? ?? '',
+      marks: [
+        for (final mark in (json['marks'] as List<dynamic>? ?? const []))
+          mark as String,
+      ],
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'type': type.name,
+      'text': text,
+      'marks': marks,
+    };
+  }
+
   RichBlock copyWith({
     RichBlockType? type,
     String? text,

--- a/lib/core/models/scene_node.dart
+++ b/lib/core/models/scene_node.dart
@@ -13,6 +13,25 @@ class SceneNode extends Equatable {
   final String title;
   final List<SceneNode> children;
 
+  factory SceneNode.fromJson(Map<String, dynamic> json) {
+    return SceneNode(
+      id: json['id'] as String,
+      title: json['title'] as String? ?? '',
+      children: [
+        for (final child in (json['children'] as List<dynamic>? ?? const []))
+          SceneNode.fromJson(Map<String, dynamic>.from(child as Map)),
+      ],
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'title': title,
+      'children': [for (final child in children) child.toJson()],
+    };
+  }
+
   SceneNode copyWith({
     String? title,
     List<SceneNode>? children,

--- a/lib/core/models/voice_profile.dart
+++ b/lib/core/models/voice_profile.dart
@@ -21,6 +21,31 @@ class VoiceProfile extends Equatable {
   final VoiceProfileStatus status;
   final bool isConsentGiven;
 
+  factory VoiceProfile.fromJson(Map<String, dynamic> json) {
+    return VoiceProfile(
+      id: json['id'] as String,
+      name: json['name'] as String? ?? '',
+      kind: json['kind'] as String? ?? 'generic',
+      locale: json['locale'] as String? ?? 'ru-RU',
+      status: VoiceProfileStatus.values.firstWhere(
+        (value) => value.name == json['status'],
+        orElse: () => VoiceProfileStatus.training,
+      ),
+      isConsentGiven: json['isConsentGiven'] as bool? ?? false,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'name': name,
+      'kind': kind,
+      'locale': locale,
+      'status': status.name,
+      'isConsentGiven': isConsentGiven,
+    };
+  }
+
   VoiceProfile copyWith({
     String? name,
     String? kind,

--- a/lib/core/providers/app_providers.dart
+++ b/lib/core/providers/app_providers.dart
@@ -1,8 +1,11 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../models/models.dart';
+import '../services/dictation_service.dart';
+import 'dictation_controller.dart';
 import 'voicebook_store.dart';
 import '../api/voicebook_api_service.dart';
+import '../storage/storage_service.dart';
 
 enum AppPermission { microphone, notifications, files }
 
@@ -64,7 +67,8 @@ final voicebookApiProvider = Provider<VoicebookApiService>((ref) {
 final voicebookStoreProvider =
     StateNotifierProvider<VoicebookStore, VoicebookStoreState>((ref) {
   final api = ref.watch(voicebookApiProvider);
-  return VoicebookStore(api);
+  final storage = ref.watch(storageServiceProvider);
+  return VoicebookStore(api, storage);
 });
 
 final notebooksProvider = Provider<List<Notebook>>((ref) {
@@ -141,4 +145,16 @@ final chapterStructureProvider =
 final voiceProfileProvider = Provider<VoiceProfile?>((ref) {
   final store = ref.watch(voicebookStoreProvider);
   return store.voiceProfile;
+});
+
+final appSettingsProvider = Provider<AppSettings?>((ref) {
+  final store = ref.watch(voicebookStoreProvider);
+  return store.settings;
+});
+
+final dictationControllerProvider =
+    StateNotifierProvider<DictationController, DictationState>((ref) {
+  final gateway = ref.watch(dictationGatewayProvider);
+  final store = ref.watch(voicebookStoreProvider.notifier);
+  return DictationController(gateway, store);
 });

--- a/lib/core/providers/dictation_controller.dart
+++ b/lib/core/providers/dictation_controller.dart
@@ -1,0 +1,251 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../services/dictation_service.dart';
+import 'voicebook_store.dart';
+
+class DictationState {
+  const DictationState({
+    this.isConnecting = false,
+    this.isListening = false,
+    this.activeBookId,
+    this.activeChapterId,
+    this.phrases = const <DictationPhrase>[],
+    this.lastCommittedId,
+    this.lastCommittedText,
+    this.error,
+  });
+
+  final bool isConnecting;
+  final bool isListening;
+  final String? activeBookId;
+  final String? activeChapterId;
+  final List<DictationPhrase> phrases;
+  final String? lastCommittedId;
+  final String? lastCommittedText;
+  final Object? error;
+
+  DictationState copyWith({
+    bool? isConnecting,
+    bool? isListening,
+    String? activeBookId,
+    String? activeChapterId,
+    List<DictationPhrase>? phrases,
+    String? lastCommittedId = _noUpdate,
+    String? lastCommittedText = _noUpdate,
+    Object? error = _noUpdate,
+  }) {
+    return DictationState(
+      isConnecting: isConnecting ?? this.isConnecting,
+      isListening: isListening ?? this.isListening,
+      activeBookId: activeBookId ?? this.activeBookId,
+      activeChapterId: activeChapterId ?? this.activeChapterId,
+      phrases: phrases ?? this.phrases,
+      lastCommittedId: identical(lastCommittedId, _noUpdate) ? this.lastCommittedId : lastCommittedId,
+      lastCommittedText:
+          identical(lastCommittedText, _noUpdate) ? this.lastCommittedText : lastCommittedText,
+      error: identical(error, _noUpdate) ? this.error : error,
+    );
+  }
+
+  static const Object _noUpdate = Object();
+}
+
+class DictationPhrase {
+  const DictationPhrase({
+    required this.id,
+    required this.text,
+    required this.status,
+  });
+
+  final String id;
+  final String text;
+  final DictationPhraseStatus status;
+}
+
+enum DictationPhraseStatus { streaming, committing, committed }
+
+class DictationController extends StateNotifier<DictationState> {
+  DictationController(this._gateway, this._store) : super(const DictationState());
+
+  final DictationGateway _gateway;
+  final VoicebookStore _store;
+
+  DictationSession? _session;
+  StreamSubscription? _subscription;
+
+  Future<void> toggle({required String bookId, required String chapterId}) async {
+    if (state.isListening || state.isConnecting) {
+      await stop();
+      return;
+    }
+    await start(bookId: bookId, chapterId: chapterId);
+  }
+
+  Future<void> start({required String bookId, required String chapterId}) async {
+    await stop();
+    state = state.copyWith(
+      isConnecting: true,
+      isListening: false,
+      activeBookId: bookId,
+      activeChapterId: chapterId,
+      phrases: const [],
+      lastCommittedId: null,
+      lastCommittedText: null,
+      error: null,
+    );
+
+    try {
+      _session = await _gateway.openSession();
+      _subscription = _session!.channel.stream.listen(
+        _handleMessage,
+        onError: (error, stackTrace) {
+          state = state.copyWith(
+            error: error,
+            isConnecting: false,
+            isListening: false,
+          );
+        },
+        onDone: () {
+          state = state.copyWith(isListening: false, isConnecting: false);
+        },
+      );
+
+      _session!.channel.sink.add(jsonEncode({'type': 'start'}));
+    } catch (error, stackTrace) {
+      state = state.copyWith(
+        error: error,
+        isConnecting: false,
+        isListening: false,
+      );
+      _subscription?.cancel();
+      _subscription = null;
+      await _session?.dispose();
+      _session = null;
+    }
+  }
+
+  Future<void> stop() async {
+    if (_session == null) {
+      state = state.copyWith(isListening: false, isConnecting: false);
+      return;
+    }
+    try {
+      _session!.channel.sink.add(jsonEncode({'type': 'stop'}));
+    } catch (_) {}
+    await _subscription?.cancel();
+    _subscription = null;
+    await _session?.dispose();
+    _session = null;
+    state = state.copyWith(
+      isListening: false,
+      isConnecting: false,
+      phrases: const [],
+      activeBookId: null,
+      activeChapterId: null,
+      lastCommittedId: null,
+      lastCommittedText: null,
+    );
+  }
+
+  void acknowledgeCommit() {
+    state = state.copyWith(lastCommittedId: null, lastCommittedText: null);
+  }
+
+  void _handleMessage(dynamic message) {
+    if (message is! String) {
+      return;
+    }
+    final dynamic data = jsonDecode(message);
+    if (data is! Map<String, dynamic>) {
+      return;
+    }
+    switch (data['type']) {
+      case 'state':
+        _handleStateMessage(data['state'] as String?);
+        break;
+      case 'frame':
+        _handleFrameMessage(data);
+        break;
+      case 'commit':
+        final phraseId = data['id'] as String?;
+        if (phraseId != null) {
+          _markCommitted(phraseId);
+        }
+        break;
+    }
+  }
+
+  void _handleStateMessage(String? value) {
+    switch (value) {
+      case 'connecting':
+        state = state.copyWith(isConnecting: true, isListening: false);
+        break;
+      case 'listening':
+        state = state.copyWith(isConnecting: false, isListening: true);
+        _session?.channel.sink.add(jsonEncode({
+          'type': 'audio',
+          'chunk': DateTime.now().millisecondsSinceEpoch,
+        }));
+        break;
+      case 'completed':
+      case 'stopped':
+        state = state.copyWith(isListening: false, isConnecting: false);
+        break;
+    }
+  }
+
+  void _handleFrameMessage(Map<String, dynamic> data) {
+    final id = data['id'] as String?;
+    final text = data['text'] as String? ?? '';
+    final statusValue = data['status'] as String? ?? 'stream';
+    if (id == null) {
+      return;
+    }
+    final status = switch (statusValue) {
+      'finalised' => DictationPhraseStatus.committing,
+      'commit' => DictationPhraseStatus.committing,
+      _ => DictationPhraseStatus.streaming,
+    };
+
+    final phrases = [...state.phrases];
+    final index = phrases.indexWhere((phrase) => phrase.id == id);
+    final updated = DictationPhrase(id: id, text: text, status: status);
+    if (index == -1) {
+      phrases.add(updated);
+    } else {
+      phrases[index] = updated;
+    }
+    state = state.copyWith(phrases: List.unmodifiable(phrases));
+  }
+
+  void _markCommitted(String phraseId) {
+    final phrases = [...state.phrases];
+    final index = phrases.indexWhere((phrase) => phrase.id == phraseId);
+    if (index == -1) {
+      return;
+    }
+    final phrase = phrases[index];
+    final committed = DictationPhrase(
+      id: phrase.id,
+      text: phrase.text,
+      status: DictationPhraseStatus.committed,
+    );
+    phrases[index] = committed;
+    state = state.copyWith(
+      phrases: List.unmodifiable(phrases),
+      lastCommittedId: phraseId,
+      lastCommittedText: committed.text,
+    );
+
+    final bookId = state.activeBookId;
+    final chapterId = state.activeChapterId;
+    if (bookId != null && chapterId != null && committed.text.trim().isNotEmpty) {
+      unawaited(
+        _store.appendDictationResult(bookId: bookId, chapterId: chapterId, text: committed.text),
+      );
+    }
+  }
+}

--- a/lib/core/providers/voicebook_store.dart
+++ b/lib/core/providers/voicebook_store.dart
@@ -1,22 +1,31 @@
+import 'dart:math';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../api/voicebook_api_service.dart';
 import '../models/models.dart';
+import '../storage/storage_service.dart';
 
 class VoicebookStoreState {
   const VoicebookStoreState({
     this.isLoading = false,
+    this.isSyncing = false,
     this.notebooks = const <Notebook>[],
     this.chaptersByBook = const <String, List<Chapter>>{},
     this.voiceProfile,
+    this.settings,
+    this.userId,
     this.error,
     this.stackTrace,
   });
 
   final bool isLoading;
+  final bool isSyncing;
   final List<Notebook> notebooks;
   final Map<String, List<Chapter>> chaptersByBook;
   final VoiceProfile? voiceProfile;
+  final AppSettings? settings;
+  final String? userId;
   final Object? error;
   final StackTrace? stackTrace;
 
@@ -24,17 +33,23 @@ class VoicebookStoreState {
 
   VoicebookStoreState copyWith({
     bool? isLoading,
+    bool? isSyncing,
     List<Notebook>? notebooks,
     Map<String, List<Chapter>>? chaptersByBook,
     VoiceProfile? voiceProfile,
+    AppSettings? settings,
+    String? userId,
     Object? error = const _NoUpdate(),
     StackTrace? stackTrace = const _NoUpdate(),
   }) {
     return VoicebookStoreState(
       isLoading: isLoading ?? this.isLoading,
+      isSyncing: isSyncing ?? this.isSyncing,
       notebooks: notebooks ?? this.notebooks,
       chaptersByBook: chaptersByBook ?? this.chaptersByBook,
       voiceProfile: voiceProfile ?? this.voiceProfile,
+      settings: settings ?? this.settings,
+      userId: userId ?? this.userId,
       error: error is _NoUpdate ? this.error : error,
       stackTrace: stackTrace is _NoUpdate ? this.stackTrace : stackTrace,
     );
@@ -42,37 +57,97 @@ class VoicebookStoreState {
 }
 
 class VoicebookStore extends StateNotifier<VoicebookStoreState> {
-  VoicebookStore(this._api)
-      : super(const VoicebookStoreState(isLoading: true)) {
+  VoicebookStore(this._api, this._storage)
+      : _random = Random.secure(),
+        super(const VoicebookStoreState(isLoading: true)) {
     _bootstrap();
   }
 
   final VoicebookApiService _api;
+  final StorageService _storage;
+  final Random _random;
 
   Future<void> _bootstrap() async {
     try {
+      final userId = await _storage.ensureUserId();
+      final localNotebooks = await _storage.loadNotebooks();
+      final localChapterMap = await _storage.loadChapterMap();
+      final localVoiceProfile = await _storage.loadVoiceProfile();
+      final localSettings = await _storage.loadSettings(userId);
+      final hasLocalData =
+          localNotebooks.isNotEmpty || localChapterMap.isNotEmpty || localVoiceProfile != null || localSettings != null;
+
+      if (hasLocalData) {
+        state = state.copyWith(
+          isLoading: false,
+          userId: userId,
+          notebooks: List.unmodifiable(localNotebooks),
+          chaptersByBook: Map.unmodifiable({
+            for (final entry in localChapterMap.entries)
+              entry.key: List<Chapter>.unmodifiable(entry.value),
+          }),
+          voiceProfile: localVoiceProfile ?? state.voiceProfile,
+          settings: localSettings ?? state.settings,
+          error: null,
+          stackTrace: null,
+        );
+      }
+
+      await _refreshFromRemote(userId: userId, hasLocalData: hasLocalData);
+    } catch (error, stackTrace) {
+      state = state.copyWith(
+        isLoading: false,
+        isSyncing: false,
+        error: error,
+        stackTrace: stackTrace,
+      );
+    }
+  }
+
+  Future<void> _refreshFromRemote({required String userId, required bool hasLocalData}) async {
+    try {
+      state = state.copyWith(isSyncing: true, userId: userId);
       final notebooks = await _api.getNotebooks();
       final chaptersByBook = <String, List<Chapter>>{};
       for (final notebook in notebooks) {
         final chapters = await _api.getChapters(notebook.id);
-        chaptersByBook[notebook.id] = List.unmodifiable(chapters);
+        chaptersByBook[notebook.id] = List<Chapter>.from(chapters);
       }
       final voiceProfile = await _api.getVoiceProfile();
+      final settings = await _api.getSettings(userId);
+
+      await _storage.saveNotebooks(notebooks);
+      for (final entry in chaptersByBook.entries) {
+        await _storage.saveChapters(entry.key, entry.value);
+      }
+      await _storage.saveVoiceProfile(voiceProfile);
+      await _storage.saveSettings(userId, settings);
 
       state = state.copyWith(
         isLoading: false,
+        isSyncing: false,
+        userId: userId,
         notebooks: List.unmodifiable(notebooks),
-        chaptersByBook: Map.unmodifiable(chaptersByBook),
+        chaptersByBook: Map.unmodifiable({
+          for (final entry in chaptersByBook.entries)
+            entry.key: List<Chapter>.unmodifiable(entry.value),
+        }),
         voiceProfile: voiceProfile,
+        settings: settings,
         error: null,
         stackTrace: null,
       );
     } catch (error, stackTrace) {
       state = state.copyWith(
         isLoading: false,
+        isSyncing: false,
+        userId: userId,
         error: error,
         stackTrace: stackTrace,
       );
+      if (!hasLocalData) {
+        rethrow;
+      }
     }
   }
 
@@ -100,6 +175,161 @@ class VoicebookStore extends StateNotifier<VoicebookStoreState> {
       }
     }
     return null;
+  }
+
+  Future<Notebook> createNotebook(String title) async {
+    final now = DateTime.now();
+    final notebook = Notebook(
+      id: _generateId('book'),
+      title: title.isEmpty ? 'Новый проект' : title,
+      updatedAt: now,
+      coverUrl: null,
+      tags: const [],
+      chapters: 0,
+      words: 0,
+      audioMinutes: 0,
+    );
+
+    final notebooks = [...state.notebooks, notebook];
+    state = state.copyWith(
+      notebooks: List.unmodifiable(notebooks),
+      error: null,
+      stackTrace: null,
+    );
+
+    final initialChapter = Chapter(
+      id: _generateId('chapter'),
+      bookId: notebook.id,
+      title: 'Новая глава',
+      subtitle: 'Черновик',
+      status: ChapterStatus.draft,
+      meta: const {'genre': 'Не указан', 'wordCount': '0'},
+      structure: const [],
+      body: 'Начните диктовку или нажмите «Сформировать текст», чтобы получить подсказку.',
+    );
+
+    try {
+      await _replaceChapters(notebook.id, [initialChapter]);
+      return notebook;
+    } catch (error, stackTrace) {
+      state = state.copyWith(error: error, stackTrace: stackTrace);
+      rethrow;
+    }
+  }
+
+  Future<void> updateChapterDraft({
+    required String bookId,
+    required String chapterId,
+    required String title,
+    required String subtitle,
+    required String body,
+  }) async {
+    final chapters = List<Chapter>.from(getChapters(bookId));
+    final index = chapters.indexWhere((chapter) => chapter.id == chapterId);
+    if (index == -1) {
+      return;
+    }
+
+    final updatedMeta = Map<String, String?>.from(chapters[index].meta);
+    updatedMeta['wordCount'] = _countWords(body).toString();
+
+    chapters[index] = chapters[index].copyWith(
+      title: title,
+      subtitle: subtitle.isEmpty ? null : subtitle,
+      body: body,
+      meta: updatedMeta,
+    );
+
+    try {
+      await _replaceChapters(bookId, chapters);
+    } catch (error, stackTrace) {
+      state = state.copyWith(error: error, stackTrace: stackTrace);
+    }
+  }
+
+  Future<void> appendDictationResult({
+    required String bookId,
+    required String chapterId,
+    required String text,
+  }) async {
+    final chapters = List<Chapter>.from(getChapters(bookId));
+    final index = chapters.indexWhere((chapter) => chapter.id == chapterId);
+    if (index == -1) {
+      return;
+    }
+
+    final current = chapters[index];
+    final trimmed = current.body.trimRight();
+    final separator = trimmed.isEmpty ? '' : '\n\n';
+    final newBody = '$trimmed$separator$text';
+    final updatedMeta = Map<String, String?>.from(current.meta);
+    updatedMeta['wordCount'] = _countWords(newBody).toString();
+
+    chapters[index] = current.copyWith(body: newBody, meta: updatedMeta);
+
+    try {
+      await _replaceChapters(bookId, chapters);
+    } catch (error, stackTrace) {
+      state = state.copyWith(error: error, stackTrace: stackTrace);
+    }
+  }
+
+  Future<void> updateSettings(AppSettings settings) async {
+    final userId = state.userId;
+    if (userId == null) {
+      return;
+    }
+    state = state.copyWith(settings: settings, error: null, stackTrace: null);
+    try {
+      await _storage.saveSettings(userId, settings);
+      await _api.syncSettings(userId, settings);
+    } catch (error, stackTrace) {
+      state = state.copyWith(error: error, stackTrace: stackTrace);
+    }
+  }
+
+  Future<void> _replaceChapters(String bookId, List<Chapter> chapters) async {
+    final normalized = List<Chapter>.from(chapters);
+    final chapterMap = Map<String, List<Chapter>>.from(state.chaptersByBook);
+    chapterMap[bookId] = List<Chapter>.unmodifiable(normalized);
+
+    final words = normalized.fold<int>(0, (value, chapter) => value + _countWords(chapter.body));
+    final notebooks = [
+      for (final notebook in state.notebooks)
+        if (notebook.id == bookId)
+          notebook.copyWith(
+            updatedAt: DateTime.now(),
+            chapters: normalized.length,
+            words: words,
+          )
+        else
+          notebook,
+    ];
+
+    final updatedNotebook = notebooks.firstWhere((notebook) => notebook.id == bookId);
+
+    state = state.copyWith(
+      notebooks: List.unmodifiable(notebooks),
+      chaptersByBook: Map.unmodifiable(chapterMap),
+      error: null,
+      stackTrace: null,
+    );
+
+    await _storage.saveChapters(bookId, normalized);
+    await _storage.saveNotebook(updatedNotebook);
+    await _api.syncChapters(bookId, normalized);
+    await _api.syncNotebook(updatedNotebook);
+  }
+
+  String _generateId(String prefix) {
+    final millis = DateTime.now().millisecondsSinceEpoch;
+    final randomPart = _random.nextInt(0xFFFFFF).toRadixString(16).padLeft(6, '0');
+    return '$prefix-$millis-$randomPart';
+  }
+
+  int _countWords(String text) {
+    final matches = RegExp(r'[^\s]+').allMatches(text.trim());
+    return matches.length;
   }
 }
 

--- a/lib/core/services/dictation_service.dart
+++ b/lib/core/services/dictation_service.dart
@@ -1,0 +1,219 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:math';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:stream_channel/stream_channel.dart';
+import 'package:web_socket_channel/web_socket_channel.dart';
+
+final dictationGatewayProvider = Provider<DictationGateway>((ref) {
+  return MockDictationGateway();
+});
+
+abstract class DictationGateway {
+  Future<DictationSession> openSession();
+}
+
+class DictationSession {
+  DictationSession(this.channel, this._cleanup);
+
+  final WebSocketChannel channel;
+  final Future<void> Function() _cleanup;
+
+  Future<void> dispose() => _cleanup();
+}
+
+class DictationFrame {
+  const DictationFrame({
+    required this.id,
+    required this.text,
+    required this.status,
+  });
+
+  final String id;
+  final String text;
+  final DictationFrameStatus status;
+}
+
+enum DictationFrameStatus { stream, commit, finalised }
+
+class MockDictationGateway implements DictationGateway {
+  MockDictationGateway({this.latency = const Duration(milliseconds: 160)})
+      : _random = Random.secure();
+
+  final Duration latency;
+  final Random _random;
+
+  @override
+  Future<DictationSession> openSession() async {
+    final controller = StreamChannelController<dynamic>(allowForeignErrors: false, sync: true);
+    final timers = <Timer>[];
+    final channel = _MockWebSocketChannel(controller);
+
+    void cancelTimers() {
+      for (final timer in timers) {
+        if (timer.isActive) {
+          timer.cancel();
+        }
+      }
+      timers.clear();
+    }
+
+    controller.local.stream.listen((message) {
+      if (message is! String) {
+        return;
+      }
+      try {
+        final data = jsonDecode(message) as Map<String, dynamic>;
+        if (data['type'] == 'start') {
+          cancelTimers();
+          _announce(controller.local.sink, 'connecting');
+          timers.add(Timer(latency, () {
+            _announce(controller.local.sink, 'listening');
+            _scheduleScript(controller.local.sink, timers);
+          }));
+        } else if (data['type'] == 'audio') {
+          _scheduleAdditionalPhrase(controller.local.sink, timers);
+        } else if (data['type'] == 'stop') {
+          cancelTimers();
+          _announce(controller.local.sink, 'stopped');
+        }
+      } catch (error, stackTrace) {
+        if (kDebugMode) {
+          // ignore: avoid_print
+          print('MockDictationGateway decode error: $error\n$stackTrace');
+        }
+      }
+    });
+
+    Future<void> cleanup() async {
+      cancelTimers();
+      await controller.local.sink.close();
+    }
+
+    return DictationSession(channel, cleanup);
+  }
+
+  void _announce(StreamSink<dynamic> sink, String state) {
+    sink.add(jsonEncode({'type': 'state', 'state': state}));
+  }
+
+  void _scheduleScript(StreamSink<dynamic> sink, List<Timer> timers) {
+    const baseScripts = [
+      [
+        _ScriptFrame(duration: Duration(milliseconds: 420), status: DictationFrameStatus.stream,
+            text: 'Вчера вечером мы собрали черновики сессии.'),
+        _ScriptFrame(duration: Duration(milliseconds: 520), status: DictationFrameStatus.stream,
+            text: 'Вчера вечером мы собрали черновики сессии и нашли сильные цитаты.'),
+        _ScriptFrame(duration: Duration(milliseconds: 560), status: DictationFrameStatus.commit,
+            text: 'Вчера вечером мы собрали черновики сессии и нашли сильные цитаты из интервью.'),
+        _ScriptFrame(duration: Duration(milliseconds: 720), status: DictationFrameStatus.finalised,
+            text: 'Вчера вечером мы собрали черновики сессии и нашли сильные цитаты из интервью.'),
+      ],
+      [
+        _ScriptFrame(duration: Duration(milliseconds: 400), status: DictationFrameStatus.stream,
+            text: 'Теперь добавим переход к следующей сцене.'),
+        _ScriptFrame(duration: Duration(milliseconds: 480), status: DictationFrameStatus.commit,
+            text: 'Теперь добавим переход к следующей сцене с упоминанием ведущей.'),
+        _ScriptFrame(duration: Duration(milliseconds: 660), status: DictationFrameStatus.finalised,
+            text: 'Теперь добавим переход к следующей сцене с упоминанием ведущей и атмосферного шума станции.'),
+      ],
+    ];
+
+    var accumulatedDelay = Duration.zero;
+    var phraseIndex = 0;
+    for (final phrase in baseScripts) {
+      phraseIndex += 1;
+      var phraseDelay = Duration.zero;
+      for (final frame in phrase) {
+        phraseDelay += frame.duration;
+        final scheduledAt = accumulatedDelay + phraseDelay;
+        final frameId = 'phrase-$phraseIndex';
+        timers.add(Timer(scheduledAt, () {
+          sink.add(
+            jsonEncode({
+              'type': 'frame',
+              'id': frameId,
+              'status': frame.status.name,
+              'text': frame.text,
+            }),
+          );
+          if (frame.status == DictationFrameStatus.finalised) {
+            sink.add(jsonEncode({'type': 'commit', 'id': frameId}));
+          }
+        }));
+      }
+      accumulatedDelay += phraseDelay + const Duration(milliseconds: 520);
+    }
+
+    timers.add(Timer(accumulatedDelay + const Duration(milliseconds: 320), () {
+      _announce(sink, 'completed');
+    }));
+  }
+
+  void _scheduleAdditionalPhrase(StreamSink<dynamic> sink, List<Timer> timers) {
+    final frameId = 'phrase-${_random.nextInt(9999)}';
+    const frames = [
+      _ScriptFrame(duration: Duration(milliseconds: 360), status: DictationFrameStatus.stream,
+          text: 'Также отмечаем эмоции собеседников.'),
+      _ScriptFrame(duration: Duration(milliseconds: 540), status: DictationFrameStatus.finalised,
+          text: 'Также отмечаем эмоции собеседников и их реакцию на туман станции.'),
+    ];
+    var accumulated = Duration.zero;
+    for (final frame in frames) {
+      accumulated += frame.duration;
+      timers.add(Timer(accumulated, () {
+        sink.add(
+          jsonEncode({
+            'type': 'frame',
+            'id': frameId,
+            'status': frame.status.name,
+            'text': frame.text,
+          }),
+        );
+        if (frame.status == DictationFrameStatus.finalised) {
+          sink.add(jsonEncode({'type': 'commit', 'id': frameId}));
+        }
+      }));
+    }
+  }
+}
+
+class _MockWebSocketChannel extends WebSocketChannel {
+  _MockWebSocketChannel(this._controller);
+
+  final StreamChannelController<dynamic> _controller;
+
+  @override
+  Stream<dynamic> get stream => _controller.foreign.stream;
+
+  @override
+  WebSocketSink get sink => _MockWebSocketSink(_controller.foreign.sink);
+}
+
+class _MockWebSocketSink extends WebSocketSink {
+  _MockWebSocketSink(this._inner);
+
+  final StreamSink<dynamic> _inner;
+
+  @override
+  void add(dynamic data) => _inner.add(data);
+
+  @override
+  void addError(Object error, [StackTrace? stackTrace]) => _inner.addError(error, stackTrace);
+
+  @override
+  Future<void> close([int? closeCode, String? closeReason]) => _inner.close();
+
+  @override
+  Future<void> get done => _inner.done;
+}
+
+class _ScriptFrame {
+  const _ScriptFrame({required this.duration, required this.status, required this.text});
+
+  final Duration duration;
+  final DictationFrameStatus status;
+  final String text;
+}

--- a/lib/core/storage/storage_service.dart
+++ b/lib/core/storage/storage_service.dart
@@ -1,5 +1,9 @@
+import 'dart:math';
+
+import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:hive/hive.dart';
+import 'package:hive_flutter/hive_flutter.dart';
 
 import '../models/models.dart';
 
@@ -8,16 +12,134 @@ final storageServiceProvider = Provider<StorageService>((ref) {
 });
 
 class StorageService {
+  StorageService();
+
+  static const _notebooksBoxKey = 'voicebook.notebooks';
+  static const _chaptersBoxKey = 'voicebook.chapters';
+  static const _settingsBoxKey = 'voicebook.settings';
+  static const _voiceProfileBoxKey = 'voicebook.voiceProfile';
+  static const _appBoxKey = 'voicebook.app';
+  static const _userIdKey = 'userId';
+
+  bool _initialized = false;
+  late Box<Map> _notebooksBox;
+  late Box<Map> _chaptersBox;
+  late Box<Map> _settingsBox;
+  late Box<Map> _voiceProfileBox;
+  late Box _appBox;
+
   Future<void> init() async {
-    // TODO: initialize Hive for mobile/web.
+    if (_initialized) {
+      return;
+    }
+
+    if (!kIsWeb && Hive.isBoxOpen(_notebooksBoxKey)) {
+      _notebooksBox = Hive.box<Map>(_notebooksBoxKey);
+      _chaptersBox = Hive.box<Map>(_chaptersBoxKey);
+      _settingsBox = Hive.box<Map>(_settingsBoxKey);
+      _voiceProfileBox = Hive.box<Map>(_voiceProfileBoxKey);
+      _appBox = Hive.box(_appBoxKey);
+      _initialized = true;
+      return;
+    }
+
+    await Hive.initFlutter();
+    _notebooksBox = await Hive.openBox<Map>(_notebooksBoxKey);
+    _chaptersBox = await Hive.openBox<Map>(_chaptersBoxKey);
+    _settingsBox = await Hive.openBox<Map>(_settingsBoxKey);
+    _voiceProfileBox = await Hive.openBox<Map>(_voiceProfileBoxKey);
+    _appBox = await Hive.openBox<dynamic>(_appBoxKey);
+    _initialized = true;
+  }
+
+  Future<String> ensureUserId() async {
+    await init();
+    final existing = _appBox.get(_userIdKey) as String?;
+    if (existing != null && existing.isNotEmpty) {
+      return existing;
+    }
+    final random = Random();
+    final buffer = StringBuffer('user-');
+    for (var i = 0; i < 32; i++) {
+      buffer.write(random.nextInt(16).toRadixString(16));
+    }
+    final userId = buffer.toString();
+    await _appBox.put(_userIdKey, userId);
+    return userId;
   }
 
   Future<List<Notebook>> loadNotebooks() async {
-    // TODO: load from Hive boxes.
-    return const [];
+    await init();
+    return [
+      for (final value in _notebooksBox.values)
+        Notebook.fromJson(Map<String, dynamic>.from(value))
+    ];
+  }
+
+  Future<Map<String, List<Chapter>>> loadChapterMap() async {
+    await init();
+    final map = <String, List<Chapter>>{};
+    for (final key in _chaptersBox.keys) {
+      final raw = _chaptersBox.get(key);
+      if (raw is List) {
+        map[key as String] = [
+          for (final entry in raw)
+            Chapter.fromJson(Map<String, dynamic>.from(entry as Map)),
+        ];
+      }
+    }
+    return map;
+  }
+
+  Future<VoiceProfile?> loadVoiceProfile() async {
+    await init();
+    final raw = _voiceProfileBox.get(_voiceProfileBoxKey);
+    if (raw is Map) {
+      return VoiceProfile.fromJson(Map<String, dynamic>.from(raw));
+    }
+    return null;
+  }
+
+  Future<AppSettings?> loadSettings(String userId) async {
+    await init();
+    final raw = _settingsBox.get(userId);
+    if (raw is Map) {
+      return AppSettings.fromJson(Map<String, dynamic>.from(raw));
+    }
+    return null;
   }
 
   Future<void> saveNotebook(Notebook notebook) async {
-    // TODO: persist notebook.
+    await init();
+    await _notebooksBox.put(notebook.id, notebook.toJson());
+  }
+
+  Future<void> saveNotebooks(Iterable<Notebook> notebooks) async {
+    await init();
+    await _notebooksBox.putAll({for (final notebook in notebooks) notebook.id: notebook.toJson()});
+  }
+
+  Future<void> removeNotebook(String notebookId) async {
+    await init();
+    await _notebooksBox.delete(notebookId);
+    await _chaptersBox.delete(notebookId);
+  }
+
+  Future<void> saveChapters(String bookId, List<Chapter> chapters) async {
+    await init();
+    await _chaptersBox.put(
+      bookId,
+      [for (final chapter in chapters) chapter.toJson()],
+    );
+  }
+
+  Future<void> saveVoiceProfile(VoiceProfile profile) async {
+    await init();
+    await _voiceProfileBox.put(_voiceProfileBoxKey, profile.toJson());
+  }
+
+  Future<void> saveSettings(String userId, AppSettings settings) async {
+    await init();
+    await _settingsBox.put(userId, settings.toJson());
   }
 }

--- a/lib/features/book_workspace/widgets/fab_panel/fab_action_cluster.dart
+++ b/lib/features/book_workspace/widgets/fab_panel/fab_action_cluster.dart
@@ -7,14 +7,18 @@ import '../../../../shared/tokens/design_tokens.dart';
 class FabActionCluster extends StatelessWidget {
   const FabActionCluster({
     super.key,
-    required this.onStartStop,
+    required this.onToggleRecording,
     required this.onOpenComposer,
     required this.onPreviewTts,
+    required this.isRecording,
+    required this.isConnecting,
   });
 
-  final VoidCallback onStartStop;
+  final VoidCallback onToggleRecording;
   final VoidCallback onOpenComposer;
   final VoidCallback onPreviewTts;
+  final bool isRecording;
+  final bool isConnecting;
 
   @override
   Widget build(BuildContext context) {
@@ -36,7 +40,11 @@ class FabActionCluster extends StatelessWidget {
           onPressed: onPreviewTts,
         ),
         const SizedBox(height: 16),
-        _MicRecordButton(onPressed: onStartStop),
+        _MicRecordButton(
+          onPressed: onToggleRecording,
+          isRecording: isRecording,
+          isConnecting: isConnecting,
+        ),
       ],
     );
   }
@@ -80,9 +88,11 @@ class _FloatingActionButton extends StatelessWidget {
 }
 
 class _MicRecordButton extends StatefulWidget {
-  const _MicRecordButton({required this.onPressed});
+  const _MicRecordButton({required this.onPressed, required this.isRecording, required this.isConnecting});
 
   final VoidCallback onPressed;
+  final bool isRecording;
+  final bool isConnecting;
 
   @override
   State<_MicRecordButton> createState() => _MicRecordButtonState();
@@ -94,8 +104,24 @@ class _MicRecordButtonState extends State<_MicRecordButton> with SingleTickerPro
   @override
   void initState() {
     super.initState();
-    _controller = AnimationController(vsync: this, duration: const Duration(seconds: 2))..repeat();
+    _controller = AnimationController(vsync: this, duration: const Duration(seconds: 2));
+    if (_shouldAnimate(widget)) {
+      _controller.repeat();
+    }
   }
+
+  @override
+  void didUpdateWidget(covariant _MicRecordButton oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    final shouldAnimate = _shouldAnimate(widget);
+    if (shouldAnimate && !_controller.isAnimating) {
+      _controller.repeat();
+    } else if (!shouldAnimate && _controller.isAnimating) {
+      _controller.stop();
+    }
+  }
+
+  bool _shouldAnimate(_MicRecordButton widget) => widget.isRecording || widget.isConnecting;
 
   @override
   void dispose() {
@@ -108,18 +134,24 @@ class _MicRecordButtonState extends State<_MicRecordButton> with SingleTickerPro
     return AnimatedBuilder(
       animation: _controller,
       builder: (context, child) {
-        final pulse = (math.sin(_controller.value * math.pi * 2) + 1) / 2;
+        final pulse = _controller.isAnimating ? (math.sin(_controller.value * math.pi * 2) + 1) / 2 : 0.0;
+        final level = widget.isRecording
+            ? pulse
+            : widget.isConnecting
+                ? 0.3 + pulse * 0.2
+                : 0.08;
         return Stack(
           alignment: Alignment.center,
           children: [
-            Container(
-              width: 92 + pulse * 16,
-              height: 92 + pulse * 16,
+            AnimatedContainer(
+              duration: const Duration(milliseconds: 200),
+              width: 92 + pulse * 18,
+              height: 92 + pulse * 18,
               decoration: BoxDecoration(
                 shape: BoxShape.circle,
                 gradient: RadialGradient(
                   colors: [
-                    AppColors.error.withOpacity(0.45 - pulse * 0.2),
+                    AppColors.error.withOpacity(widget.isRecording ? 0.45 - pulse * 0.2 : 0.18),
                     AppColors.error.withOpacity(0.1),
                   ],
                 ),
@@ -129,16 +161,34 @@ class _MicRecordButtonState extends State<_MicRecordButton> with SingleTickerPro
               style: ElevatedButton.styleFrom(
                 shape: const CircleBorder(),
                 padding: const EdgeInsets.all(28),
-                backgroundColor: AppColors.error,
+                backgroundColor:
+                    widget.isRecording ? AppColors.error : AppColors.error.withOpacity(widget.isConnecting ? 0.8 : 1),
                 foregroundColor: Colors.white,
                 elevation: 10,
               ),
               onPressed: widget.onPressed,
-              child: const Icon(Icons.mic, size: 36),
+              child: Icon(widget.isRecording ? Icons.stop : Icons.mic, size: 36),
             ),
             Positioned(
               bottom: -12,
-              child: _LevelMeter(level: pulse),
+              child: Column(
+                children: [
+                  _LevelMeter(level: level),
+                  const SizedBox(height: 6),
+                  AnimatedSwitcher(
+                    duration: const Duration(milliseconds: 250),
+                    child: Text(
+                      widget.isConnecting
+                          ? 'Подключение...'
+                          : widget.isRecording
+                              ? 'Нажмите, чтобы остановить'
+                              : 'Надиктовать',
+                      key: ValueKey('${widget.isRecording}-${widget.isConnecting}'),
+                      style: Theme.of(context).textTheme.labelSmall?.copyWith(color: Colors.white),
+                    ),
+                  ),
+                ],
+              ),
             ),
           ],
         );

--- a/lib/features/settings/settings_screen.dart
+++ b/lib/features/settings/settings_screen.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../core/models/models.dart';
+import '../../core/providers/app_providers.dart';
 import '../../shared/ui/glass_card.dart';
 
 class SettingsScreen extends ConsumerWidget {
@@ -8,28 +10,40 @@ class SettingsScreen extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final settings = ref.watch(appSettingsProvider);
+    if (settings == null) {
+      return const Scaffold(
+        appBar: AppBar(title: Text('Настройки')),
+        body: Center(child: CircularProgressIndicator()),
+      );
+    }
+
     return Scaffold(
       appBar: AppBar(title: const Text('Настройки')),
       body: ListView(
         padding: const EdgeInsets.all(24),
-        children: const [
-          _SectionHeader(title: 'Распознавание речи'),
-          _AsrSettings(),
-          SizedBox(height: 24),
-          _SectionHeader(title: 'AI Composer'),
-          _AiSettings(),
-          SizedBox(height: 24),
-          _SectionHeader(title: 'Озвучка'),
-          _TtsSettings(),
-          SizedBox(height: 24),
-          _SectionHeader(title: 'Синхронизация'),
-          _SyncSettings(),
-          SizedBox(height: 24),
-          _SectionHeader(title: 'Голосовые команды'),
-          _CommandsSettings(),
+        children: [
+          const _SectionHeader(title: 'Распознавание речи'),
+          _AsrSettings(settings: settings, onChanged: (value) => _update(ref, value)),
+          const SizedBox(height: 24),
+          const _SectionHeader(title: 'AI Composer'),
+          _AiSettings(settings: settings, onChanged: (value) => _update(ref, value)),
+          const SizedBox(height: 24),
+          const _SectionHeader(title: 'Озвучка'),
+          _TtsSettings(settings: settings, onChanged: (value) => _update(ref, value)),
+          const SizedBox(height: 24),
+          const _SectionHeader(title: 'Синхронизация'),
+          _SyncSettings(settings: settings, onChanged: (value) => _update(ref, value)),
+          const SizedBox(height: 24),
+          const _SectionHeader(title: 'Голосовые команды'),
+          _CommandsSettings(settings: settings, onChanged: (value) => _update(ref, value)),
         ],
       ),
     );
+  }
+
+  void _update(WidgetRef ref, AppSettings settings) {
+    ref.read(voicebookStoreProvider.notifier).updateSettings(settings);
   }
 }
 
@@ -45,7 +59,10 @@ class _SectionHeader extends StatelessWidget {
 }
 
 class _AsrSettings extends StatelessWidget {
-  const _AsrSettings();
+  const _AsrSettings({required this.settings, required this.onChanged});
+
+  final AppSettings settings;
+  final ValueChanged<AppSettings> onChanged;
 
   @override
   Widget build(BuildContext context) {
@@ -53,22 +70,30 @@ class _AsrSettings extends StatelessWidget {
       child: Column(
         children: [
           SwitchListTile(
-            value: true,
-            onChanged: (_) {},
+            value: settings.autoPunctuation,
+            onChanged: (value) => onChanged(settings.copyWith(autoPunctuation: value)),
             title: const Text('Автопунктуация'),
             subtitle: const Text('Автоматически расставляет точки и запятые'),
           ),
           ListTile(
             title: const Text('Язык по умолчанию'),
-            subtitle: const Text('Русский'),
+            subtitle: Text(settings.defaultLanguage),
             trailing: const Icon(Icons.chevron_right),
-            onTap: () {},
+            onTap: () {
+              ScaffoldMessenger.of(context).showSnackBar(
+                const SnackBar(content: Text('Выбор языка появится в следующей версии.')),
+              );
+            },
           ),
           ListTile(
             title: const Text('Fallback-политика'),
-            subtitle: const Text('WS → HTTP → Офлайн буфер'),
+            subtitle: Text(settings.fallbackPolicy),
             trailing: const Icon(Icons.chevron_right),
-            onTap: () {},
+            onTap: () {
+              ScaffoldMessenger.of(context).showSnackBar(
+                const SnackBar(content: Text('Настройка fallback скоро станет интерактивной.')),
+              );
+            },
           ),
         ],
       ),
@@ -77,7 +102,10 @@ class _AsrSettings extends StatelessWidget {
 }
 
 class _AiSettings extends StatelessWidget {
-  const _AiSettings();
+  const _AiSettings({required this.settings, required this.onChanged});
+
+  final AppSettings settings;
+  final ValueChanged<AppSettings> onChanged;
 
   @override
   Widget build(BuildContext context) {
@@ -86,21 +114,29 @@ class _AiSettings extends StatelessWidget {
         children: [
           ListTile(
             title: const Text('Провайдер'),
-            subtitle: const Text('Voicebook AI'),
+            subtitle: Text(settings.aiProvider),
             trailing: const Icon(Icons.chevron_right),
-            onTap: () {},
+            onTap: () {
+              ScaffoldMessenger.of(context).showSnackBar(
+                const SnackBar(content: Text('Добавим выбор провайдера позже.')),
+              );
+            },
           ),
           ListTile(
             title: const Text('Лимит токенов в день'),
-            subtitle: const Text('Осталось 8 500'),
+            subtitle: Text('Осталось ${settings.dailyTokenLimit}'),
             trailing: const Icon(Icons.chevron_right),
-            onTap: () {},
+            onTap: () {
+              ScaffoldMessenger.of(context).showSnackBar(
+                const SnackBar(content: Text('Редактирование лимитов появится позже.')),
+              );
+            },
           ),
           ListTile(
             title: const Text('Пресет стиля по умолчанию'),
-            subtitle: const Text('Научно-популярный'),
+            subtitle: Text(settings.defaultAiPreset),
             trailing: const Icon(Icons.chevron_right),
-            onTap: () {},
+            onTap: () => onChanged(settings.copyWith(defaultAiPreset: settings.defaultAiPreset)),
           ),
         ],
       ),
@@ -109,7 +145,10 @@ class _AiSettings extends StatelessWidget {
 }
 
 class _TtsSettings extends StatelessWidget {
-  const _TtsSettings();
+  const _TtsSettings({required this.settings, required this.onChanged});
+
+  final AppSettings settings;
+  final ValueChanged<AppSettings> onChanged;
 
   @override
   Widget build(BuildContext context) {
@@ -117,16 +156,20 @@ class _TtsSettings extends StatelessWidget {
       child: Column(
         children: [
           SwitchListTile(
-            value: true,
-            onChanged: (_) {},
+            value: settings.usePersonalVoice,
+            onChanged: (value) => onChanged(settings.copyWith(usePersonalVoice: value)),
             title: const Text('Использовать персональный голос'),
             subtitle: const Text('Недоступно без завершения тренировки'),
           ),
           ListTile(
             title: const Text('Голос по умолчанию'),
-            subtitle: const Text('Night Station v2'),
+            subtitle: Text(settings.defaultVoice),
             trailing: const Icon(Icons.chevron_right),
-            onTap: () {},
+            onTap: () {
+              ScaffoldMessenger.of(context).showSnackBar(
+                const SnackBar(content: Text('Скоро можно будет выбрать другой голос.')),
+              );
+            },
           ),
         ],
       ),
@@ -135,7 +178,10 @@ class _TtsSettings extends StatelessWidget {
 }
 
 class _SyncSettings extends StatelessWidget {
-  const _SyncSettings();
+  const _SyncSettings({required this.settings, required this.onChanged});
+
+  final AppSettings settings;
+  final ValueChanged<AppSettings> onChanged;
 
   @override
   Widget build(BuildContext context) {
@@ -144,15 +190,15 @@ class _SyncSettings extends StatelessWidget {
         children: [
           RadioListTile<String>(
             value: 'local',
-            groupValue: 'cloud',
-            onChanged: (_) {},
+            groupValue: settings.syncStrategy,
+            onChanged: (value) => onChanged(settings.copyWith(syncStrategy: value ?? settings.syncStrategy)),
             title: const Text('Только локально'),
             subtitle: const Text('Данные остаются на устройстве'),
           ),
           RadioListTile<String>(
             value: 'cloud',
-            groupValue: 'cloud',
-            onChanged: (_) {},
+            groupValue: settings.syncStrategy,
+            onChanged: (value) => onChanged(settings.copyWith(syncStrategy: value ?? settings.syncStrategy)),
             title: const Text('С облачной синхронизацией'),
             subtitle: const Text('Резервное копирование и доступ с других устройств'),
           ),
@@ -163,32 +209,63 @@ class _SyncSettings extends StatelessWidget {
 }
 
 class _CommandsSettings extends StatelessWidget {
-  const _CommandsSettings();
+  const _CommandsSettings({required this.settings, required this.onChanged});
+
+  final AppSettings settings;
+  final ValueChanged<AppSettings> onChanged;
 
   @override
   Widget build(BuildContext context) {
-    final commands = ['"Новая глава"', '"Начать запись"', '"Перефразируй абзац"'];
     return GlassCard(
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           SwitchListTile(
-            value: true,
-            onChanged: (_) {},
+            value: settings.voiceCommandsEnabled,
+            onChanged: (value) => onChanged(settings.copyWith(voiceCommandsEnabled: value)),
             title: const Text('Включить голосовые команды'),
           ),
           const Divider(),
-          ...commands.map(
+          ...settings.voiceCommands.map(
             (command) => ListTile(
               leading: const Icon(Icons.record_voice_over),
               title: Text(command),
-              trailing: const Icon(Icons.edit_outlined),
-              onTap: () {},
+              trailing: IconButton(
+                icon: const Icon(Icons.delete_outline),
+                onPressed: () {
+                  final updated = List<String>.from(settings.voiceCommands)..remove(command);
+                  onChanged(settings.copyWith(voiceCommands: updated));
+                },
+              ),
             ),
           ),
           const SizedBox(height: 12),
           OutlinedButton.icon(
-            onPressed: () {},
+            onPressed: () async {
+              final controller = TextEditingController();
+              final result = await showDialog<String>(
+                context: context,
+                builder: (context) => AlertDialog(
+                  title: const Text('Новая команда'),
+                  content: TextField(
+                    controller: controller,
+                    autofocus: true,
+                    decoration: const InputDecoration(hintText: 'Например: "Добавь сцену"'),
+                  ),
+                  actions: [
+                    TextButton(onPressed: () => Navigator.of(context).pop(), child: const Text('Отмена')),
+                    FilledButton(
+                      onPressed: () => Navigator.of(context).pop(controller.text.trim()),
+                      child: const Text('Сохранить'),
+                    ),
+                  ],
+                ),
+              );
+              if (result != null && result.isNotEmpty) {
+                final updated = List<String>.from(settings.voiceCommands)..add('"$result"');
+                onChanged(settings.copyWith(voiceCommands: updated));
+              }
+            },
             icon: const Icon(Icons.add),
             label: const Text('Добавить команду'),
           ),


### PR DESCRIPTION
## Summary
- wire up Hive-backed storage for notebooks, chapters, voice profile and app settings with API synchronisation fallbacks
- extend the domain models and mock API to serialise data, support user settings and allow notebook creation from the UI
- introduce a mock dictation WebSocket gateway with controller and animated editor overlays, and refresh the settings and library screens to operate on local data

## Testing
- `flutter analyze` *(fails: flutter is not installed in the environment)*
- `dart format lib` *(fails: dart is not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_b_68d717644fb48322adb1913309c628d5