### PR TITLE
Fix mock services and provider typing issues

### DIFF
--- a/lib/core/models/chapter.dart
+++ b/lib/core/models/chapter.dart
@@ -46,7 +46,7 @@ class Chapter extends Equatable {
         orElse: () => ChapterStatus.draft,
       ),
       meta: {
-        for (final entry in (json['meta'] as Map<String, dynamic>? ?? const {}))
+        for (final entry in (json['meta'] as Map<String, dynamic>? ?? const <String, dynamic>{}))
           entry.key: entry.value as String?,
       },
       structure: [

--- a/lib/core/providers/app_providers.dart
+++ b/lib/core/providers/app_providers.dart
@@ -61,7 +61,7 @@ final permissionsProvider =
     StateNotifierProvider<PermissionController, PermissionState>((ref) => PermissionController());
 
 final voicebookApiProvider = Provider<VoicebookApiService>((ref) {
-  return const MockVoicebookApiService();
+  return MockVoicebookApiService();
 });
 
 final voicebookStoreProvider =

--- a/lib/core/providers/dictation_controller.dart
+++ b/lib/core/providers/dictation_controller.dart
@@ -33,8 +33,8 @@ class DictationState {
     String? activeBookId,
     String? activeChapterId,
     List<DictationPhrase>? phrases,
-    String? lastCommittedId = _noUpdate,
-    String? lastCommittedText = _noUpdate,
+    Object? lastCommittedId = _noUpdate,
+    Object? lastCommittedText = _noUpdate,
     Object? error = _noUpdate,
   }) {
     return DictationState(
@@ -43,9 +43,12 @@ class DictationState {
       activeBookId: activeBookId ?? this.activeBookId,
       activeChapterId: activeChapterId ?? this.activeChapterId,
       phrases: phrases ?? this.phrases,
-      lastCommittedId: identical(lastCommittedId, _noUpdate) ? this.lastCommittedId : lastCommittedId,
-      lastCommittedText:
-          identical(lastCommittedText, _noUpdate) ? this.lastCommittedText : lastCommittedText,
+      lastCommittedId: identical(lastCommittedId, _noUpdate)
+          ? this.lastCommittedId
+          : lastCommittedId as String?,
+      lastCommittedText: identical(lastCommittedText, _noUpdate)
+          ? this.lastCommittedText
+          : lastCommittedText as String?,
       error: identical(error, _noUpdate) ? this.error : error,
     );
   }

--- a/lib/core/providers/voicebook_store.dart
+++ b/lib/core/providers/voicebook_store.dart
@@ -40,7 +40,7 @@ class VoicebookStoreState {
     AppSettings? settings,
     String? userId,
     Object? error = const _NoUpdate(),
-    StackTrace? stackTrace = const _NoUpdate(),
+    Object? stackTrace = const _NoUpdate(),
   }) {
     return VoicebookStoreState(
       isLoading: isLoading ?? this.isLoading,
@@ -51,7 +51,7 @@ class VoicebookStoreState {
       settings: settings ?? this.settings,
       userId: userId ?? this.userId,
       error: error is _NoUpdate ? this.error : error,
-      stackTrace: stackTrace is _NoUpdate ? this.stackTrace : stackTrace,
+      stackTrace: stackTrace is _NoUpdate ? this.stackTrace : stackTrace as StackTrace?,
     );
   }
 }

--- a/lib/core/services/dictation_service.dart
+++ b/lib/core/services/dictation_service.dart
@@ -180,19 +180,32 @@ class MockDictationGateway implements DictationGateway {
   }
 }
 
-class _MockWebSocketChannel extends WebSocketChannel {
+class _MockWebSocketChannel implements WebSocketChannel {
   _MockWebSocketChannel(this._controller);
 
   final StreamChannelController<dynamic> _controller;
+  WebSocketSink? _sink;
 
   @override
   Stream<dynamic> get stream => _controller.foreign.stream;
 
   @override
-  WebSocketSink get sink => _MockWebSocketSink(_controller.foreign.sink);
+  WebSocketSink get sink => _sink ??= _MockWebSocketSink(_controller.foreign.sink);
+
+  @override
+  Future<void> get ready => Future<void>.value();
+
+  @override
+  String? get protocol => null;
+
+  @override
+  int? get closeCode => null;
+
+  @override
+  String? get closeReason => null;
 }
 
-class _MockWebSocketSink extends WebSocketSink {
+class _MockWebSocketSink implements WebSocketSink {
   _MockWebSocketSink(this._inner);
 
   final StreamSink<dynamic> _inner;
@@ -202,6 +215,9 @@ class _MockWebSocketSink extends WebSocketSink {
 
   @override
   void addError(Object error, [StackTrace? stackTrace]) => _inner.addError(error, stackTrace);
+
+  @override
+  Future<void> addStream(Stream<dynamic> stream) => _inner.addStream(stream);
 
   @override
   Future<void> close([int? closeCode, String? closeReason]) => _inner.close();

--- a/lib/core/storage/storage_service.dart
+++ b/lib/core/storage/storage_service.dart
@@ -23,7 +23,7 @@ class StorageService {
 
   bool _initialized = false;
   late Box<Map> _notebooksBox;
-  late Box<Map> _chaptersBox;
+  late Box<List> _chaptersBox;
   late Box<Map> _settingsBox;
   late Box<Map> _voiceProfileBox;
   late Box _appBox;
@@ -35,7 +35,7 @@ class StorageService {
 
     if (!kIsWeb && Hive.isBoxOpen(_notebooksBoxKey)) {
       _notebooksBox = Hive.box<Map>(_notebooksBoxKey);
-      _chaptersBox = Hive.box<Map>(_chaptersBoxKey);
+      _chaptersBox = Hive.box<List>(_chaptersBoxKey);
       _settingsBox = Hive.box<Map>(_settingsBoxKey);
       _voiceProfileBox = Hive.box<Map>(_voiceProfileBoxKey);
       _appBox = Hive.box(_appBoxKey);
@@ -45,7 +45,7 @@ class StorageService {
 
     await Hive.initFlutter();
     _notebooksBox = await Hive.openBox<Map>(_notebooksBoxKey);
-    _chaptersBox = await Hive.openBox<Map>(_chaptersBoxKey);
+    _chaptersBox = await Hive.openBox<List>(_chaptersBoxKey);
     _settingsBox = await Hive.openBox<Map>(_settingsBoxKey);
     _voiceProfileBox = await Hive.openBox<Map>(_voiceProfileBoxKey);
     _appBox = await Hive.openBox<dynamic>(_appBoxKey);

--- a/lib/features/book_workspace/widgets/editor/chapter_editor.dart
+++ b/lib/features/book_workspace/widgets/editor/chapter_editor.dart
@@ -26,7 +26,6 @@ class _ChapterEditorState extends ConsumerState<ChapterEditor> {
   late final FocusNode _editorFocusNode;
   late final TextEditingController _titleController;
   late final TextEditingController _subtitleController;
-  ProviderSubscription<DictationState>? _dictationSubscription;
   Timer? _saveTimer;
   bool _saving = false;
   _AiActionState _aiActionState = _AiActionState.idle;
@@ -40,7 +39,7 @@ class _ChapterEditorState extends ConsumerState<ChapterEditor> {
     _editorFocusNode = FocusNode();
     _titleController = TextEditingController(text: widget.chapter.title);
     _subtitleController = TextEditingController(text: widget.chapter.subtitle ?? '');
-    _dictationSubscription = ref.listen<DictationState>(
+    ref.listen<DictationState>(
       dictationControllerProvider,
       (previous, next) {
         if (next.lastCommittedText != null && next.lastCommittedText!.trim().isNotEmpty) {
@@ -65,7 +64,6 @@ class _ChapterEditorState extends ConsumerState<ChapterEditor> {
 
   @override
   void dispose() {
-    _dictationSubscription?.close();
     _controller.removeListener(_scheduleAutosave);
     _controller.dispose();
     _scrollController.dispose();

--- a/lib/features/library/library_screen.dart
+++ b/lib/features/library/library_screen.dart
@@ -18,9 +18,9 @@ class LibraryScreen extends ConsumerWidget {
     final notebooks = ref.watch(notebooksProvider);
 
     if (storeState.isLoading) {
-      return const Scaffold(
-        appBar: AppBar(title: Text('Библиотека')),
-        body: Center(child: CircularProgressIndicator()),
+      return Scaffold(
+        appBar: AppBar(title: const Text('Библиотека')),
+        body: const Center(child: CircularProgressIndicator()),
       );
     }
 

--- a/lib/features/settings/settings_screen.dart
+++ b/lib/features/settings/settings_screen.dart
@@ -12,9 +12,9 @@ class SettingsScreen extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final settings = ref.watch(appSettingsProvider);
     if (settings == null) {
-      return const Scaffold(
-        appBar: AppBar(title: Text('Настройки')),
-        body: Center(child: CircularProgressIndicator()),
+      return Scaffold(
+        appBar: AppBar(title: const Text('Настройки')),
+        body: const Center(child: CircularProgressIndicator()),
       );
     }
 


### PR DESCRIPTION
## Summary
- update the mock WebSocket channel and sink to implement the current interfaces
- fix provider defaults, store copyWith sentinels, and storage types to address analyzer failures
- clean up UI widgets to remove invalid consts and rely on Riverpod-managed listeners

## Testing
- Not run (Flutter CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_b_68d71cedfbd08322a4426efa2b1ee5ee