### PR TITLE
Fix Flutter mock channel and provider compilation issues

### DIFF
--- a/lib/core/models/chapter.dart
+++ b/lib/core/models/chapter.dart
@@ -15,7 +15,7 @@ class Chapter extends Equatable {
     required this.title,
     this.subtitle,
     this.status = ChapterStatus.draft,
-    this.meta = const {},
+    this.meta = const <String, String?>{},
     this.structure = const [],
     this.blocks = const [],
     this.body = '',
@@ -46,7 +46,7 @@ class Chapter extends Equatable {
         orElse: () => ChapterStatus.draft,
       ),
       meta: {
-        for (final entry in (json['meta'] as Map<String, dynamic>? ?? const <String, dynamic>{}))
+        for (final entry in (json['meta'] as Map<String, dynamic>? ?? const <String, dynamic>{}).entries)
           entry.key: entry.value as String?,
       },
       structure: [

--- a/lib/core/providers/app_providers.dart
+++ b/lib/core/providers/app_providers.dart
@@ -72,8 +72,8 @@ final voicebookStoreProvider =
 });
 
 final notebooksProvider = Provider<List<Notebook>>((ref) {
-  final store = ref.watch(voicebookStoreProvider);
-  return store.notebooks;
+  final state = ref.watch(voicebookStoreProvider);
+  return state.notebooks;
 });
 
 Chapter? _findChapter(List<Chapter> chapters, String chapterId) {
@@ -85,22 +85,31 @@ Chapter? _findChapter(List<Chapter> chapters, String chapterId) {
   return null;
 }
 
+Notebook? _findNotebook(List<Notebook> notebooks, String bookId) {
+  for (final notebook in notebooks) {
+    if (notebook.id == bookId) {
+      return notebook;
+    }
+  }
+  return null;
+}
+
 final bookProvider = Provider.family<Notebook?, String>((ref, bookId) {
-  final store = ref.watch(voicebookStoreProvider);
-  return store.findNotebook(bookId);
+  final state = ref.watch(voicebookStoreProvider);
+  return _findNotebook(state.notebooks, bookId);
 });
 
 final bookExistsProvider = Provider.family<bool, String>((ref, bookId) {
-  final store = ref.watch(voicebookStoreProvider);
-  if (store.isLoading) {
+  final state = ref.watch(voicebookStoreProvider);
+  if (state.isLoading) {
     return true;
   }
-  return store.findNotebook(bookId) != null;
+  return _findNotebook(state.notebooks, bookId) != null;
 });
 
 final bookChaptersProvider = Provider.family<List<Chapter>, String>((ref, bookId) {
-  final store = ref.watch(voicebookStoreProvider);
-  return store.getChapters(bookId);
+  final state = ref.watch(voicebookStoreProvider);
+  return state.chaptersByBook[bookId] ?? const <Chapter>[];
 });
 
 final chapterSummariesProvider = Provider.family<List<ChapterSummary>, String>((ref, bookId) {

--- a/lib/core/services/dictation_service.dart
+++ b/lib/core/services/dictation_service.dart
@@ -186,17 +186,53 @@ class _MockWebSocketChannel implements WebSocketChannel {
   final StreamChannelController<dynamic> _controller;
   WebSocketSink? _sink;
 
-  @override
-  Stream<dynamic> get stream => _controller.foreign.stream;
+  StreamChannel<dynamic> get _channel => _controller.foreign;
 
   @override
-  WebSocketSink get sink => _sink ??= _MockWebSocketSink(_controller.foreign.sink);
+  Stream<dynamic> get stream => _channel.stream;
+
+  @override
+  WebSocketSink get sink => _sink ??= _MockWebSocketSink(_channel.sink);
 
   @override
   Future<void> get ready => Future<void>.value();
 
   @override
   String? get protocol => null;
+
+  @override
+  StreamChannel<S> cast<S>() => _channel.cast<S>();
+
+  @override
+  StreamChannel<dynamic> changeSink(
+    StreamSink<dynamic> Function(StreamSink<dynamic>) change,
+  ) =>
+      _channel.changeSink(change);
+
+  @override
+  StreamChannel<dynamic> changeStream(
+    Stream<dynamic> Function(Stream<dynamic>) change,
+  ) =>
+      _channel.changeStream(change);
+
+  @override
+  void pipe(StreamChannel<dynamic> other) => _channel.pipe(other);
+
+  @override
+  StreamChannel<S> transform<S>(StreamChannelTransformer<S, dynamic> transformer) =>
+      _channel.transform(transformer);
+
+  @override
+  StreamChannel<dynamic> transformSink(
+    StreamSinkTransformer<dynamic, dynamic> transformer,
+  ) =>
+      _channel.transformSink(transformer);
+
+  @override
+  StreamChannel<dynamic> transformStream(
+    StreamTransformer<dynamic, dynamic> transformer,
+  ) =>
+      _channel.transformStream(transformer);
 
   @override
   int? get closeCode => null;


### PR DESCRIPTION
## Summary
- implement the missing StreamChannel behavior on the mock WebSocket channel used by the dictation gateway
- update providers to consume state directly instead of calling unavailable store helpers
- fix chapter meta parsing to iterate safely over entry pairs

## Testing
- flutter analyze *(fails: Flutter SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_b_68d71e34a6a083229fd3ce6d09f6b6a3