### PR TITLE
Add stream_channel dependency

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,6 +16,7 @@ dependencies:
   flutter_riverpod: ^2.5.1
   dio: ^5.4.2+1
   web_socket_channel: ^3.0.1
+  stream_channel: ^2.1.2
   flutter_quill: ^11.4.2
   record: ^6.1.1
   just_audio: ^0.10.5


### PR DESCRIPTION
## Summary
- add a direct dependency on stream_channel so StreamSinkTransformer is available in web builds

## Testing
- flutter pub get *(fails: Flutter SDK not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_b_68d71f25e1f08322980b1189986ad307