### PR TITLE
Fix missing StreamSinkTransformer import

### DIFF
--- a/lib/core/services/dictation_service.dart
+++ b/lib/core/services/dictation_service.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:math';
 
+import 'package:async/async.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:stream_channel/stream_channel.dart';


### PR DESCRIPTION
## Summary
- import `package:async/async.dart` so the mock dictation channel can reference `StreamSinkTransformer`

## Testing
- not run (Flutter/Dart SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_b_68d7223dce848322a907726fda99b6f3