### PR TITLE
Fix Riverpod dictation listener initialization in ChapterEditor

### DIFF
--- a/lib/features/book_workspace/widgets/editor/chapter_editor.dart
+++ b/lib/features/book_workspace/widgets/editor/chapter_editor.dart
@@ -26,6 +26,7 @@ class _ChapterEditorState extends ConsumerState<ChapterEditor> {
   late final FocusNode _editorFocusNode;
   late final TextEditingController _titleController;
   late final TextEditingController _subtitleController;
+  late final ProviderSubscription<DictationState> _dictationSubscription;
   Timer? _saveTimer;
   bool _saving = false;
   _AiActionState _aiActionState = _AiActionState.idle;
@@ -39,7 +40,7 @@ class _ChapterEditorState extends ConsumerState<ChapterEditor> {
     _editorFocusNode = FocusNode();
     _titleController = TextEditingController(text: widget.chapter.title);
     _subtitleController = TextEditingController(text: widget.chapter.subtitle ?? '');
-    ref.listen<DictationState>(
+    _dictationSubscription = ref.listenManual<DictationState>(
       dictationControllerProvider,
       (previous, next) {
         if (next.lastCommittedText != null && next.lastCommittedText!.trim().isNotEmpty) {
@@ -71,6 +72,7 @@ class _ChapterEditorState extends ConsumerState<ChapterEditor> {
     _titleController.dispose();
     _subtitleController.dispose();
     _saveTimer?.cancel();
+    unawaited(_dictationSubscription.close());
     super.dispose();
   }
 


### PR DESCRIPTION
## Summary
- replace the ChapterEditor dictation listener with a manual Riverpod subscription to avoid build-time assertions
- close the manual subscription during disposal to prevent leaks

## Testing
- not run (flutter CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_b_68d72355e9fc8322bd14ae7b6f1b60c7