### PR TITLE
Fix dictation subscription disposal

### DIFF
--- a/lib/features/book_workspace/widgets/editor/chapter_editor.dart
+++ b/lib/features/book_workspace/widgets/editor/chapter_editor.dart
@@ -72,7 +72,7 @@ class _ChapterEditorState extends ConsumerState<ChapterEditor> {
     _titleController.dispose();
     _subtitleController.dispose();
     _saveTimer?.cancel();
-    unawaited(_dictationSubscription.close());
+    _dictationSubscription.close();
     super.dispose();
   }
 


### PR DESCRIPTION
## Summary
- remove the incorrect `unawaited` wrapper around the dictation subscription `close` call so disposal builds on web

## Testing
- `flutter analyze` *(fails: flutter not installed in container)*

------
https://chatgpt.com/codex/tasks/task_b_68d723f6fcdc8322bd7c41938708a9b3