### PR TITLE
Implement chapter management improvements

### DIFF
--- a/lib/features/book_workspace/book_workspace_screen.dart
+++ b/lib/features/book_workspace/book_workspace_screen.dart
@@ -91,15 +91,30 @@ class BookWorkspaceScreen extends ConsumerWidget {
             onSelect: (chapterId) {
               ref.read(currentChapterIdProvider(bookId).notifier).state = chapterId;
             },
-            onAdd: () {
-              ScaffoldMessenger.of(context).showSnackBar(
-                const SnackBar(content: Text('Добавление новых глав включится в полной версии.')),
-              );
+            onAdd: () async {
+              final notifier = ref.read(voicebookStoreProvider.notifier);
+              try {
+                final chapter = await notifier.createChapter(bookId);
+                if (context.mounted) {
+                  ref.read(currentChapterIdProvider(bookId).notifier).state = chapter.id;
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    SnackBar(content: Text('Глава «${chapter.title}» добавлена.')), 
+                  );
+                }
+              } catch (error) {
+                if (context.mounted) {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(content: Text('Не удалось добавить главу. Попробуйте ещё раз.')),
+                  );
+                }
+              }
             },
             onReorder: (oldIndex, newIndex) {
-              ScaffoldMessenger.of(context).showSnackBar(
-                const SnackBar(content: Text('Перестановка глав сохранится при подключении хранилища.')),
-              );
+              ref.read(voicebookStoreProvider.notifier).reorderChapters(
+                    bookId: bookId,
+                    oldIndex: oldIndex,
+                    newIndex: newIndex,
+                  );
             },
           ),
         );


### PR DESCRIPTION
## Summary
- enable creating and reordering chapters through the voicebook store and workspace
- redesign the chapter ruler for compact layouts with a responsive add button
- update the editor overlays with a collapsible dictation panel and sliding AI hints

## Testing
- flutter analyze *(fails: flutter CLI unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_b_68d727ba383c8322a6329bd1493598ac