### PR TITLE
Expand ChapterRuler to full width in compact view

### DIFF
--- a/lib/features/book_workspace/widgets/chapter_ruler/chapter_ruler.dart
+++ b/lib/features/book_workspace/widgets/chapter_ruler/chapter_ruler.dart
@@ -242,7 +242,7 @@ class _ChapterRulerState extends State<ChapterRuler> with SingleTickerProviderSt
     final rulerWidth = widget.width;
 
     return SizedBox(
-      width: rulerWidth,
+      width: compact ? double.infinity : rulerWidth,
       child: ClipRRect(
         borderRadius: const BorderRadius.horizontal(right: Radius.circular(16)),
         child: DecoratedBox(


### PR DESCRIPTION
## Summary
- let ChapterRuler use the full available width when rendered in compact layouts so it spans the screen

## Testing
- not run (Flutter SDK unavailable in container)


------
https://chatgpt.com/codex/tasks/task_b_68d7a826addc8322a79dcd7f0bbc6161