### PR TITLE
Make ChapterRuler a collapsible left rail

### DIFF
--- a/lib/features/book_workspace/widgets/chapter_ruler/chapter_ruler.dart
+++ b/lib/features/book_workspace/widgets/chapter_ruler/chapter_ruler.dart
@@ -242,7 +242,7 @@ class _ChapterRulerState extends State<ChapterRuler> with SingleTickerProviderSt
     final rulerWidth = widget.width;
 
     return SizedBox(
-      width: compact ? double.infinity : rulerWidth,
+      width: rulerWidth,
       child: ClipRRect(
         borderRadius: const BorderRadius.horizontal(right: Radius.circular(16)),
         child: DecoratedBox(


### PR DESCRIPTION
## Summary
- convert the book workspace screen to keep ChapterRuler docked on the left across breakpoints and add a slide-out toggle
- add animated padding/positioning so the ruler can collapse leftward without covering the editor
- fix ChapterRuler sizing so the compact layout still uses the configured rail width

## Testing
- not run (Flutter tooling is unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_b_68d7a9cceeb0832287e3ea984c0ee1fb