### PR TITLE
Revamp book workspace layout

### DIFF
--- a/lib/app/theme.dart
+++ b/lib/app/theme.dart
@@ -26,7 +26,26 @@ class AppTheme {
         elevation: 0,
         surfaceTintColor: Colors.transparent,
       ),
-      textTheme: AppTypography.textTheme,
+      textTheme: AppTypography.textTheme.copyWith(
+        headlineSmall: AppTypography.textTheme.headlineLarge?.copyWith(fontSize: 26, fontWeight: FontWeight.w600),
+        bodyMedium: AppTypography.textTheme.bodyLarge?.copyWith(fontSize: 16, height: 1.6),
+        labelLarge: AppTypography.textTheme.labelMedium?.copyWith(fontWeight: FontWeight.w600),
+      ),
+      cardTheme: CardTheme(
+        color: Colors.white.withOpacity(0.65),
+        elevation: 0,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(AppSpacing.radiusMedium),
+          side: const BorderSide(color: AppColors.border),
+        ),
+      ),
+      elevatedButtonTheme: ElevatedButtonThemeData(
+        style: ElevatedButton.styleFrom(
+          elevation: 3,
+          padding: const EdgeInsets.symmetric(horizontal: 18, vertical: 14),
+          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(AppSpacing.radiusMedium)),
+        ),
+      ),
       chipTheme: base.chipTheme.copyWith(
         shape: RoundedRectangleBorder(
           borderRadius: BorderRadius.circular(AppSpacing.radiusMedium),
@@ -45,11 +64,13 @@ class AppTheme {
       floatingActionButtonTheme: const FloatingActionButtonThemeData(
         shape: StadiumBorder(),
       ),
+      shadowColor: Colors.black.withOpacity(0.12),
     );
   }
 
   ThemeData get darkTheme {
     final base = ThemeData.dark(useMaterial3: true);
+    final textTheme = AppTypography.textTheme.apply(bodyColor: Colors.white);
     return base.copyWith(
       colorScheme: ColorScheme.fromSeed(
         brightness: Brightness.dark,
@@ -65,7 +86,11 @@ class AppTheme {
         elevation: 0,
         surfaceTintColor: Colors.transparent,
       ),
-      textTheme: AppTypography.textTheme.apply(bodyColor: Colors.white),
+      textTheme: textTheme.copyWith(
+        headlineSmall: textTheme.headlineLarge?.copyWith(fontSize: 26, fontWeight: FontWeight.w600),
+        bodyMedium: textTheme.bodyLarge?.copyWith(fontSize: 16, height: 1.6),
+        labelLarge: textTheme.labelMedium?.copyWith(fontWeight: FontWeight.w600),
+      ),
       chipTheme: base.chipTheme.copyWith(
         shape: RoundedRectangleBorder(
           borderRadius: BorderRadius.circular(AppSpacing.radiusMedium),

--- a/lib/core/storage/ui_state_storage.dart
+++ b/lib/core/storage/ui_state_storage.dart
@@ -1,0 +1,40 @@
+import 'package:hive_flutter/hive_flutter.dart';
+
+class UiStateStorage {
+  UiStateStorage._(this._box);
+
+  static const _boxName = 'ui_state';
+  static const _rulerPrefix = 'chapterRulerScrollOffset::';
+  static const _activeChapterPrefix = 'activeChapter::';
+
+  final Box<dynamic> _box;
+
+  static Future<UiStateStorage> open() async {
+    final box = await Hive.openBox<dynamic>(_boxName);
+    return UiStateStorage._(box);
+  }
+
+  double? readChapterRulerOffset(String bookId) {
+    final value = _box.get('$_rulerPrefix$bookId');
+    if (value is num) {
+      return value.toDouble();
+    }
+    return null;
+  }
+
+  Future<void> writeChapterRulerOffset(String bookId, double offset) {
+    return _box.put('$_rulerPrefix$bookId', offset);
+  }
+
+  String? readActiveChapterId(String bookId) {
+    final value = _box.get('$_activeChapterPrefix$bookId');
+    if (value is String) {
+      return value;
+    }
+    return null;
+  }
+
+  Future<void> writeActiveChapterId(String bookId, String chapterId) {
+    return _box.put('$_activeChapterPrefix$bookId', chapterId);
+  }
+}

--- a/lib/features/book_workspace/widgets/chapter_header_card/chapter_header_card.dart
+++ b/lib/features/book_workspace/widgets/chapter_header_card/chapter_header_card.dart
@@ -1,0 +1,122 @@
+import 'dart:ui';
+
+import 'package:flutter/material.dart';
+
+import 'package:voicebook/shared/tokens/design_tokens.dart';
+
+class ChapterHeaderCard extends StatelessWidget {
+  const ChapterHeaderCard({
+    super.key,
+    required this.titleController,
+    required this.subtitleController,
+    required this.metaChips,
+    required this.onOpenStructure,
+    required this.saved,
+    this.wordCount,
+    this.titleFocusNode,
+    this.subtitleFocusNode,
+    this.onTitleChanged,
+    this.onSubtitleChanged,
+  });
+
+  final TextEditingController titleController;
+  final TextEditingController subtitleController;
+  final List<Widget> metaChips;
+  final VoidCallback onOpenStructure;
+  final bool saved;
+  final int? wordCount;
+  final FocusNode? titleFocusNode;
+  final FocusNode? subtitleFocusNode;
+  final ValueChanged<String>? onTitleChanged;
+  final ValueChanged<String>? onSubtitleChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final surfaceColor = Colors.white.withOpacity(0.65);
+    final borderColor = AppColors.border.withOpacity(0.18);
+
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(AppSpacing.radiusMedium),
+      child: BackdropFilter(
+        filter: ImageFilter.blur(sigmaX: 12, sigmaY: 12),
+        child: Container(
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(AppSpacing.radiusMedium),
+            color: surfaceColor,
+            border: Border.all(color: borderColor),
+            boxShadow: const [
+              BoxShadow(color: Colors.black12, blurRadius: 10, offset: Offset(0, 4)),
+            ],
+          ),
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              TextField(
+                controller: titleController,
+                focusNode: titleFocusNode,
+                style: theme.textTheme.headlineSmall?.copyWith(fontWeight: FontWeight.w600, height: 1.2),
+                decoration: const InputDecoration(
+                  border: InputBorder.none,
+                  isDense: true,
+                  hintText: 'Глава без названия',
+                ),
+                onChanged: onTitleChanged,
+              ),
+              const SizedBox(height: 6),
+              TextField(
+                controller: subtitleController,
+                focusNode: subtitleFocusNode,
+                style: const TextStyle(color: Color(0xFF64748B), fontSize: 16),
+                decoration: const InputDecoration(
+                  border: InputBorder.none,
+                  isDense: true,
+                  hintText: 'Подзаголовок',
+                ),
+                onChanged: onSubtitleChanged,
+              ),
+              const SizedBox(height: 12),
+              Wrap(
+                spacing: 8,
+                runSpacing: 8,
+                children: [
+                  ...metaChips,
+                  OutlinedButton.icon(
+                    onPressed: onOpenStructure,
+                    icon: const Icon(Icons.hub),
+                    label: const Text('Структура'),
+                    style: OutlinedButton.styleFrom(
+                      foregroundColor: AppColors.primary,
+                      backgroundColor: Colors.white.withOpacity(0.5),
+                      side: BorderSide(color: borderColor),
+                      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+                      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 12),
+              Row(
+                children: [
+                  Icon(saved ? Icons.check_circle : Icons.sync, size: 18, color: saved ? AppColors.accent : AppColors.secondary),
+                  const SizedBox(width: 8),
+                  Text(saved ? 'Сохранено' : 'Сохраняем...', style: const TextStyle(color: Color(0xFF64748B), fontSize: 13)),
+                  const Spacer(),
+                  if (wordCount != null)
+                    Row(
+                      children: [
+                        const Icon(Icons.speed, size: 16, color: Color(0xFF64748B)),
+                        const SizedBox(width: 6),
+                        Text('$wordCount слов', style: const TextStyle(color: Color(0xFF64748B), fontSize: 13)),
+                      ],
+                    ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/book_workspace/widgets/editor/editor_toolbar.dart
+++ b/lib/features/book_workspace/widgets/editor/editor_toolbar.dart
@@ -1,0 +1,148 @@
+import 'dart:ui';
+
+import 'package:flutter/material.dart';
+
+import 'package:voicebook/shared/tokens/design_tokens.dart';
+
+enum EditorCommand {
+  undo,
+  redo,
+  heading1,
+  heading2,
+  bold,
+  italic,
+  bulletList,
+  more,
+}
+
+class EditorToolbar extends StatelessWidget {
+  const EditorToolbar({super.key, required this.onCommand});
+
+  final ValueChanged<EditorCommand> onCommand;
+
+  @override
+  Widget build(BuildContext context) {
+    final borderColor = AppColors.border.withOpacity(0.32);
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(14),
+      child: BackdropFilter(
+        filter: ImageFilter.blur(sigmaX: 12, sigmaY: 12),
+        child: Container(
+          decoration: BoxDecoration(
+            color: Colors.white.withOpacity(0.55),
+            borderRadius: BorderRadius.circular(14),
+            border: Border.all(color: borderColor),
+            boxShadow: const [
+              BoxShadow(color: Colors.black12, blurRadius: 10, offset: Offset(0, 4)),
+            ],
+          ),
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              _ToolbarIcon(
+                icon: Icons.undo,
+                tooltip: 'Назад',
+                onTap: () => onCommand(EditorCommand.undo),
+              ),
+              _ToolbarIcon(
+                icon: Icons.redo,
+                tooltip: 'Вперёд',
+                onTap: () => onCommand(EditorCommand.redo),
+              ),
+              const _ToolbarDivider(),
+              _ToolbarIcon(
+                icon: Icons.title,
+                tooltip: 'Заголовок H1',
+                onTap: () => onCommand(EditorCommand.heading1),
+              ),
+              _ToolbarIcon(
+                icon: Icons.subtitles,
+                tooltip: 'Заголовок H2',
+                onTap: () => onCommand(EditorCommand.heading2),
+              ),
+              const _ToolbarDivider(),
+              _ToolbarIcon(
+                icon: Icons.format_bold,
+                tooltip: 'Жирный',
+                onTap: () => onCommand(EditorCommand.bold),
+              ),
+              _ToolbarIcon(
+                icon: Icons.format_italic,
+                tooltip: 'Курсив',
+                onTap: () => onCommand(EditorCommand.italic),
+              ),
+              _ToolbarIcon(
+                icon: Icons.format_list_bulleted,
+                tooltip: 'Маркированный список',
+                onTap: () => onCommand(EditorCommand.bulletList),
+              ),
+              const _ToolbarDivider(),
+              _ToolbarIcon(
+                icon: Icons.more_horiz,
+                tooltip: 'Больше инструментов',
+                onTap: () => onCommand(EditorCommand.more),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _ToolbarIcon extends StatefulWidget {
+  const _ToolbarIcon({required this.icon, required this.tooltip, required this.onTap});
+
+  final IconData icon;
+  final String tooltip;
+  final VoidCallback onTap;
+
+  @override
+  State<_ToolbarIcon> createState() => _ToolbarIconState();
+}
+
+class _ToolbarIconState extends State<_ToolbarIcon> {
+  bool _hovered = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final hoverColor = AppColors.primary.withOpacity(0.12);
+    return MouseRegion(
+      onEnter: (_) => setState(() => _hovered = true),
+      onExit: (_) => setState(() => _hovered = false),
+      cursor: SystemMouseCursors.click,
+      child: Tooltip(
+        message: widget.tooltip,
+        child: GestureDetector(
+          onTap: widget.onTap,
+          child: AnimatedContainer(
+            duration: const Duration(milliseconds: 120),
+            curve: Curves.easeInOut,
+            margin: const EdgeInsets.symmetric(horizontal: 2),
+            padding: const EdgeInsets.all(8),
+            decoration: BoxDecoration(
+              color: _hovered ? hoverColor : Colors.transparent,
+              borderRadius: BorderRadius.circular(10),
+            ),
+            child: Icon(widget.icon, size: 20, color: const Color(0xFF0F172A)),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _ToolbarDivider extends StatelessWidget {
+  const _ToolbarDivider();
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 1,
+      height: 24,
+      margin: const EdgeInsets.symmetric(horizontal: 6),
+      color: AppColors.border.withOpacity(0.4),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- restyled the book workspace with a glass ChapterHeaderCard, compact editor toolbar, and refreshed chapter ruler visuals
- introduced UiStateStorage to persist chapter ruler scroll offset and last active chapter across sessions
- redesigned the FAB action cluster with animated mic controls, AI/TTS shortcuts, and timer feedback, plus tuned theme typography and shadows

## Testing
- not run (Flutter SDK unavailable in container)


------
https://chatgpt.com/codex/tasks/task_b_68d7b5d389d0832294e8283df83762cc