### PR TITLE
Fix proxy decorator parameter order

### DIFF
--- a/lib/features/book_workspace/widgets/chapter_ruler/chapter_ruler.dart
+++ b/lib/features/book_workspace/widgets/chapter_ruler/chapter_ruler.dart
@@ -219,7 +219,7 @@ class _ChapterRulerState extends State<ChapterRuler> {
       primary: false,
       buildDefaultDragHandles: false,
       itemCount: widget.chapters.length,
-      proxyDecorator: (context, child, animation) {
+      proxyDecorator: (child, index, animation) {
         return AnimatedBuilder(
           animation: animation,
           builder: (context, _) {


### PR DESCRIPTION
## Summary
- fix the proxy decorator lambda signature for the chapter ruler reorderable list to match the expected parameters
- ensure the dragged tile is passed through correctly without treating the index as the widget

## Testing
- `flutter analyze` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_b_68d7c2bff42483229d17a9d32f51b3a2