### PR TITLE
Fix ReorderableListView controller argument

### DIFF
--- a/lib/features/book_workspace/widgets/chapter_ruler_v2.dart
+++ b/lib/features/book_workspace/widgets/chapter_ruler_v2.dart
@@ -175,7 +175,7 @@ class _ChapterRulerV2State extends State<ChapterRulerV2> {
                     child: Padding(
                       padding: const EdgeInsets.only(top: 24, bottom: 104),
                       child: ReorderableListView.builder(
-                        controller: _scrollController,
+                        scrollController: _scrollController,
                         buildDefaultDragHandles: false,
                         padding: EdgeInsets.only(
                           left: 16,


### PR DESCRIPTION
## Summary
- update chapter ruler widget to use the current `scrollController` argument when constructing the reorderable list

## Testing
- flutter analyze *(fails: Flutter SDK is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_b_68d7d83821f083228e1e42746ca79302