### PR TITLE
Fix missing item keys in chapter ruler reorderable list

### DIFF
--- a/lib/features/book_workspace/widgets/chapter_ruler_v2.dart
+++ b/lib/features/book_workspace/widgets/chapter_ruler_v2.dart
@@ -187,8 +187,9 @@ class _ChapterRulerV2State extends State<ChapterRulerV2> {
                           final active = chapter.id == widget.activeChapterId;
                           final accent = _chapterAccentColor(chapter.id);
                           final canDrag = kIsWeb || Theme.of(context).platform != TargetPlatform.android;
+                          final itemKey = ValueKey(chapter.id);
                           final tile = _ChapterTab(
-                            key: ValueKey(chapter.id),
+                            key: canDrag ? null : itemKey,
                             id: chapter.id,
                             title: chapter.title,
                             active: active,
@@ -200,6 +201,7 @@ class _ChapterRulerV2State extends State<ChapterRulerV2> {
                             return tile;
                           }
                           return ReorderableDragStartListener(
+                            key: itemKey,
                             index: index,
                             child: tile,
                           );


### PR DESCRIPTION
## Summary
- ensure each reorderable chapter tile has a stable key even when wrapped in a drag handle
- avoid assigning duplicate keys by only keeping the key on the outermost widget when drag handles are enabled

## Testing
- not run (Flutter tooling unavailable in container)

------
https://chatgpt.com/codex/tasks/task_b_68d7d9c94dc48322b9c966ad65533b32