### PR TITLE
Add close support to editor gate controller

### DIFF
--- a/lib/features/book_workspace/widgets/editor_gate.dart
+++ b/lib/features/book_workspace/widgets/editor_gate.dart
@@ -52,6 +52,13 @@ class _EditorGateState extends State<EditorGate> with SingleTickerProviderStateM
     widget.onOpen();
   }
 
+  void close() {
+    if (!_open) {
+      return;
+    }
+    setState(() => _open = false);
+  }
+
   @override
   void dispose() {
     widget.controller?._detach(this);
@@ -90,6 +97,10 @@ class EditorGateController {
 
   void open() {
     _state?.open();
+  }
+
+  void close() {
+    _state?.close();
   }
 
   void _attach(_EditorGateState state) {


### PR DESCRIPTION
## Summary
- add a close API to EditorGate and expose it through EditorGateController
- allow consumers such as the workspace screen to return to the overview without errors

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68dbd9b6203483228bad2b975cf6bbc5