### PR TITLE
Implement spine-based notebook overview UI

### DIFF
--- a/lib/features/book_workspace/spine_notebook/chapter_line_tile.dart
+++ b/lib/features/book_workspace/spine_notebook/chapter_line_tile.dart
@@ -1,0 +1,113 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+
+import 'spine_tab.dart';
+
+class ChapterLineTile extends StatelessWidget {
+  const ChapterLineTile({
+    super.key,
+    required this.index,
+    required this.title,
+    required this.color,
+    required this.active,
+    required this.lineHeight,
+    required this.spineWidth,
+    required this.onTap,
+  });
+
+  final int index;
+  final String title;
+  final Color color;
+  final bool active;
+  final double lineHeight;
+  final double spineWidth;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final availableWidth = constraints.maxWidth;
+        final textMaxWidth = availableWidth - spineWidth - 24 - 32;
+
+        int measureLines(double fontSize) {
+          final painter = TextPainter(
+            text: TextSpan(
+              text: title,
+              style: TextStyle(
+                fontSize: fontSize,
+                fontWeight: FontWeight.w700,
+                height: 1.25,
+                color: const Color(0xFF0F172A),
+              ),
+            ),
+            textDirection: TextDirection.ltr,
+            maxLines: 999,
+          );
+          painter.layout(maxWidth: textMaxWidth.clamp(0, double.infinity).toDouble());
+          return painter.computeLineMetrics().length;
+        }
+
+        double fontSize = 16;
+        int linesNeeded = measureLines(fontSize);
+        if (linesNeeded > 2) {
+          fontSize = math.max(13, 16 - 1.5 * (linesNeeded - 2));
+          linesNeeded = measureLines(fontSize);
+        }
+        final int lines = linesNeeded.clamp(1, 4) as int;
+        final rowHeight = lines * lineHeight;
+
+        return Padding(
+          padding: const EdgeInsets.symmetric(vertical: 4),
+          child: SizedBox(
+            height: rowHeight,
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                ConstrainedBox(
+                  constraints: const BoxConstraints(
+                    minWidth: SpineTab.baseWidth,
+                    maxWidth: SpineTab.hoverWidth,
+                  ),
+                  child: SpineTab(
+                    index: index,
+                    lines: lines,
+                    lineHeight: lineHeight,
+                    color: color,
+                    active: active,
+                    onTap: onTap,
+                  ),
+                ),
+                Expanded(
+                  child: InkWell(
+                    onTap: onTap,
+                    borderRadius: BorderRadius.circular(8),
+                    child: Padding(
+                      padding: const EdgeInsets.symmetric(horizontal: 16),
+                      child: Align(
+                        alignment: Alignment.centerLeft,
+                        child: Text(
+                          title,
+                          maxLines: lines,
+                          overflow: TextOverflow.ellipsis,
+                          softWrap: true,
+                          style: TextStyle(
+                            fontSize: fontSize,
+                            fontWeight: FontWeight.w700,
+                            height: 1.25,
+                            color: const Color(0xFF0F172A),
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/features/book_workspace/spine_notebook/ruled_viewport.dart
+++ b/lib/features/book_workspace/spine_notebook/ruled_viewport.dart
@@ -1,0 +1,149 @@
+import 'dart:math';
+import 'dart:ui' as ui;
+
+import 'package:flutter/material.dart';
+
+class RuledViewport extends StatelessWidget {
+  const RuledViewport({
+    super.key,
+    required this.controller,
+    this.lineHeight = 28,
+    this.spineWidth = 104,
+    required this.child,
+  });
+
+  final ScrollController controller;
+  final double lineHeight;
+  final double spineWidth;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      children: [
+        Positioned.fill(
+          child: _RuledBackground(
+            controller: controller,
+            lineHeight: lineHeight,
+            spineWidth: spineWidth,
+          ),
+        ),
+        child,
+      ],
+    );
+  }
+}
+
+class _RuledBackground extends StatefulWidget {
+  const _RuledBackground({
+    required this.controller,
+    required this.lineHeight,
+    required this.spineWidth,
+  });
+
+  final ScrollController controller;
+  final double lineHeight;
+  final double spineWidth;
+
+  @override
+  State<_RuledBackground> createState() => _RuledBackgroundState();
+}
+
+class _RuledBackgroundState extends State<_RuledBackground> {
+  @override
+  void initState() {
+    super.initState();
+    widget.controller.addListener(_redraw);
+  }
+
+  @override
+  void didUpdateWidget(covariant _RuledBackground oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.controller != widget.controller) {
+      oldWidget.controller.removeListener(_redraw);
+      widget.controller.addListener(_redraw);
+    }
+  }
+
+  void _redraw() {
+    if (mounted) {
+      setState(() {});
+    }
+  }
+
+  @override
+  void dispose() {
+    widget.controller.removeListener(_redraw);
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final offset = widget.controller.hasClients ? widget.controller.offset : 0.0;
+    return CustomPaint(
+      painter: _RuledPainter(
+        offset: offset,
+        lineHeight: widget.lineHeight,
+        spineWidth: widget.spineWidth,
+      ),
+    );
+  }
+}
+
+class _RuledPainter extends CustomPainter {
+  const _RuledPainter({
+    required this.offset,
+    required this.lineHeight,
+    required this.spineWidth,
+  });
+
+  final double offset;
+  final double lineHeight;
+  final double spineWidth;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final baseY = -(offset % lineHeight);
+    final linePaint = Paint()
+      ..color = const Color(0xFFCBD5E1).withOpacity(0.28)
+      ..strokeWidth = 1;
+    for (double y = baseY; y < size.height; y += lineHeight) {
+      canvas.drawLine(Offset(spineWidth, y), Offset(size.width, y), linePaint);
+    }
+
+    final marginPaint = Paint()
+      ..color = const Color(0xFFEF4444).withOpacity(0.40)
+      ..strokeWidth = 2;
+    canvas.drawLine(
+      Offset(spineWidth + 24, 0),
+      Offset(spineWidth + 24, size.height),
+      marginPaint,
+    );
+
+    final noisePaint = Paint()
+      ..color = const Color(0xFF1E293B).withOpacity(0.06)
+      ..strokeCap = StrokeCap.round
+      ..strokeWidth = 1;
+    final random = Random(137);
+    for (double y = 0; y < size.height; y += 6) {
+      for (double x = spineWidth; x < size.width; x += 6) {
+        if (random.nextDouble() > 0.55) {
+          final dx = random.nextDouble() * 2;
+          final dy = random.nextDouble() * 2;
+          canvas.drawPoints(
+            ui.PointMode.points,
+            [Offset(x + dx, y + dy)],
+            noisePaint,
+          );
+        }
+      }
+    }
+  }
+
+  @override
+  bool shouldRepaint(covariant _RuledPainter oldDelegate) {
+    return oldDelegate.offset != offset ||
+        oldDelegate.lineHeight != lineHeight ||
+        oldDelegate.spineWidth != spineWidth;
+  }
+}

--- a/lib/features/book_workspace/spine_notebook/spine_notebook_view.dart
+++ b/lib/features/book_workspace/spine_notebook/spine_notebook_view.dart
@@ -1,0 +1,232 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+
+import 'package:voicebook/core/models/chapter_summary.dart';
+
+import 'chapter_line_tile.dart';
+import 'ruled_viewport.dart';
+import 'spine_tab.dart';
+
+class SpineNotebookView extends StatefulWidget {
+  const SpineNotebookView({
+    super.key,
+    required this.bookTitle,
+    required this.chapters,
+    required this.activeId,
+    required this.onOpen,
+    required this.onAdd,
+  });
+
+  final String bookTitle;
+  final List<ChapterSummary> chapters;
+  final String? activeId;
+  final ValueChanged<String> onOpen;
+  final VoidCallback onAdd;
+
+  @override
+  State<SpineNotebookView> createState() => _SpineNotebookViewState();
+}
+
+class _SpineNotebookViewState extends State<SpineNotebookView> {
+  static const double _lineHeight = 28;
+  static const double _spineWidth = 104;
+
+  final ScrollController _controller = ScrollController();
+  bool _showAddButton = false;
+  Timer? _revealTimer;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller.addListener(_handleScroll);
+  }
+
+  @override
+  void dispose() {
+    _revealTimer?.cancel();
+    _controller.removeListener(_handleScroll);
+    _controller.dispose();
+    super.dispose();
+  }
+
+  void _handleScroll() {
+    _setAddVisibility(false);
+    _revealTimer?.cancel();
+    _revealTimer = Timer(const Duration(milliseconds: 360), () {
+      if (mounted) {
+        _setAddVisibility(true);
+      }
+    });
+  }
+
+  void _setAddVisibility(bool visible) {
+    if (_showAddButton != visible) {
+      setState(() => _showAddButton = visible);
+    }
+  }
+
+  void _handlePointerHover(bool hovering) {
+    if (hovering) {
+      _setAddVisibility(true);
+    } else {
+      _setAddVisibility(false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final chapters = widget.chapters;
+
+    return Stack(
+      children: [
+        RuledViewport(
+          controller: _controller,
+          lineHeight: _lineHeight,
+          spineWidth: _spineWidth,
+          child: ListView.builder(
+            controller: _controller,
+            padding: const EdgeInsets.only(bottom: 120),
+            itemCount: chapters.length + 1,
+            itemBuilder: (context, index) {
+              if (index == 0) {
+                return _NotebookHeader(
+                  title: widget.bookTitle,
+                  lineHeight: _lineHeight,
+                  spineWidth: _spineWidth,
+                );
+              }
+              final chapter = chapters[index - 1];
+              final isActive = chapter.id == widget.activeId;
+              return ChapterLineTile(
+                index: index,
+                title: chapter.title,
+                color: _colorFor(chapter.id),
+                active: isActive,
+                lineHeight: _lineHeight,
+                spineWidth: _spineWidth,
+                onTap: () => widget.onOpen(chapter.id),
+              );
+            },
+          ),
+        ),
+        Positioned(
+          left: 0,
+          top: 0,
+          bottom: 0,
+          width: _spineWidth,
+          child: MouseRegion(
+            onEnter: (_) => _handlePointerHover(true),
+            onExit: (_) => _handlePointerHover(false),
+            child: const SizedBox.expand(),
+          ),
+        ),
+        Positioned(
+          left: 12,
+          bottom: 12,
+          child: GestureDetector(
+            onTap: widget.onAdd,
+            onLongPressStart: (_) => _setAddVisibility(true),
+            onLongPressEnd: (_) => _setAddVisibility(false),
+            child: AnimatedOpacity(
+              opacity: _showAddButton ? 1 : 0,
+              duration: const Duration(milliseconds: 200),
+              curve: Curves.easeOutCubic,
+              child: IgnorePointer(
+                ignoring: !_showAddButton,
+                child: _GhostAddTab(lineHeight: _lineHeight),
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _GhostAddTab extends StatelessWidget {
+  const _GhostAddTab({required this.lineHeight});
+
+  final double lineHeight;
+
+  @override
+  Widget build(BuildContext context) {
+    final height = lineHeight * 2;
+    return Container(
+      height: height,
+      width: SpineTab.baseWidth,
+      decoration: BoxDecoration(
+        color: Colors.white.withOpacity(0.32),
+        borderRadius: const BorderRadius.horizontal(right: Radius.circular(18)),
+        border: Border.all(color: const Color(0xFF2563EB).withOpacity(0.4), width: 1),
+      ),
+      child: const Center(
+        child: Icon(Icons.add, color: Color(0xFF1D4ED8), size: 24),
+      ),
+    );
+  }
+}
+
+class _NotebookHeader extends StatelessWidget {
+  const _NotebookHeader({
+    required this.title,
+    required this.lineHeight,
+    required this.spineWidth,
+  });
+
+  final String title;
+  final double lineHeight;
+  final double spineWidth;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final height = lineHeight * 2;
+    return SizedBox(
+      height: height,
+      child: Row(
+        children: [
+          SizedBox(width: spineWidth),
+          Expanded(
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16),
+              child: Align(
+                alignment: Alignment.bottomLeft,
+                child: Text(
+                  title,
+                  style: theme.textTheme.headlineSmall?.copyWith(
+                    fontWeight: FontWeight.w700,
+                    color: const Color(0xFF0F172A),
+                  ),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+const List<Color> _pastelPalette = <Color>[
+  Color(0xFFE8E7FE),
+  Color(0xFFEDE6FB),
+  Color(0xFFE6FAFD),
+  Color(0xFFEFFBF2),
+  Color(0xFFFFF3E4),
+  Color(0xFFFFE9ED),
+  Color(0xFFE6F0FF),
+  Color(0xFFEAF7FF),
+  Color(0xFFF2E7FF),
+  Color(0xFFE7FFF6),
+];
+
+Color _colorFor(String id) {
+  if (id.isEmpty) {
+    return _pastelPalette.first;
+  }
+  final hash = id.codeUnits.fold<int>(0, (acc, unit) => (acc * 31 + unit) & 0x7fffffff);
+  return _pastelPalette[hash % _pastelPalette.length];
+}

--- a/lib/features/book_workspace/spine_notebook/spine_tab.dart
+++ b/lib/features/book_workspace/spine_notebook/spine_tab.dart
@@ -1,0 +1,254 @@
+import 'dart:ui';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+
+class SpineTab extends StatefulWidget {
+  const SpineTab({
+    super.key,
+    required this.index,
+    required this.lines,
+    required this.lineHeight,
+    required this.color,
+    required this.active,
+    required this.onTap,
+  });
+
+  final int index;
+  final int lines;
+  final double lineHeight;
+  final Color color;
+  final bool active;
+  final VoidCallback onTap;
+
+  static const double baseWidth = 104;
+  static const double hoverWidth = 132;
+
+  @override
+  State<SpineTab> createState() => _SpineTabState();
+}
+
+class _SpineTabState extends State<SpineTab> {
+  bool _hovered = false;
+  bool get _isHoverEnabled => kIsWeb || defaultTargetPlatform == TargetPlatform.macOS || defaultTargetPlatform == TargetPlatform.windows || defaultTargetPlatform == TargetPlatform.linux;
+
+  void _setHovered(bool value) {
+    if (!_isHoverEnabled) {
+      return;
+    }
+    if (_hovered != value) {
+      setState(() => _hovered = value);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final height = widget.lines * widget.lineHeight;
+    final radius = Radius.circular(20);
+    final width = _hovered ? SpineTab.hoverWidth : SpineTab.baseWidth;
+
+    final decoration = BoxDecoration(
+      gradient: const LinearGradient(
+        colors: [Color(0xFF312E81), Color(0xFF5B21B6)],
+        begin: Alignment.topCenter,
+        end: Alignment.bottomCenter,
+      ),
+      borderRadius: BorderRadius.only(topRight: radius, bottomRight: radius),
+      boxShadow: [
+        if (widget.active)
+          BoxShadow(color: const Color(0xFF06B6D4).withOpacity(0.38), blurRadius: 18, spreadRadius: 1)
+        else
+          BoxShadow(color: Colors.black.withOpacity(0.18), blurRadius: 14, offset: const Offset(0, 8)),
+      ],
+    );
+
+    final bookmark = _ChapterBookmark(
+      color: widget.color,
+      radius: radius,
+    );
+
+    final badge = Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+      decoration: BoxDecoration(
+        color: Colors.black.withOpacity(0.36),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: Colors.white.withOpacity(0.35), width: 1),
+        boxShadow: const [
+          BoxShadow(color: Color(0x26000000), blurRadius: 10, spreadRadius: 1),
+        ],
+      ),
+      child: Text(
+        widget.index.toString().padLeft(2, '0'),
+        style: const TextStyle(
+          fontFeatures: [FontFeature.tabularFigures()],
+          fontSize: 14,
+          fontWeight: FontWeight.w700,
+          letterSpacing: 0.6,
+          color: Colors.white,
+        ),
+      ),
+    );
+
+    final content = GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onTap: widget.onTap,
+      child: AnimatedContainer(
+        duration: const Duration(milliseconds: 180),
+        curve: Curves.easeOutCubic,
+        width: width,
+        height: height,
+        decoration: decoration,
+        clipBehavior: Clip.antiAlias,
+        child: Stack(
+          fit: StackFit.expand,
+          children: [
+            Positioned.fill(
+              child: BackdropFilter(
+                filter: ImageFilter.blur(sigmaX: 18, sigmaY: 18),
+                child: const SizedBox(),
+              ),
+            ),
+            Positioned.fill(
+              child: DecoratedBox(
+                decoration: BoxDecoration(
+                  gradient: LinearGradient(
+                    colors: [
+                      Colors.white.withOpacity(0.18),
+                      Colors.white.withOpacity(0.04),
+                    ],
+                    begin: Alignment.topLeft,
+                    end: Alignment.bottomRight,
+                  ),
+                ),
+              ),
+            ),
+            Positioned.fill(child: bookmark),
+            const _SpineGrooves(),
+            Align(
+              alignment: Alignment.centerRight,
+              child: Container(
+                width: 18,
+                decoration: const BoxDecoration(
+                  gradient: LinearGradient(
+                    begin: Alignment.centerLeft,
+                    end: Alignment.centerRight,
+                    colors: [Color(0x00FFFFFF), Color(0x66FFFFFF)],
+                  ),
+                ),
+              ),
+            ),
+            if (widget.active)
+              Positioned(
+                left: 0,
+                top: 0,
+                bottom: 0,
+                child: Container(
+                  width: 2.5,
+                  decoration: const BoxDecoration(
+                    gradient: LinearGradient(
+                      colors: [Color(0xFF22D3EE), Color(0xFF67E8F9)],
+                      begin: Alignment.topCenter,
+                      end: Alignment.bottomCenter,
+                    ),
+                  ),
+              ),
+            ),
+            Positioned.fill(
+              child: Padding(
+                padding: const EdgeInsets.only(left: 16, right: 20),
+                child: Align(
+                  alignment: Alignment.center,
+                  child: badge,
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+
+    if (_isHoverEnabled) {
+      return MouseRegion(
+        onEnter: (_) => _setHovered(true),
+        onExit: (_) => _setHovered(false),
+        child: content,
+      );
+    }
+    return content;
+  }
+}
+
+class _SpineGrooves extends StatelessWidget {
+  const _SpineGrooves();
+
+  @override
+  Widget build(BuildContext context) {
+    return CustomPaint(
+      painter: _SpineGroovesPainter(),
+    );
+  }
+}
+
+class _SpineGroovesPainter extends CustomPainter {
+  @override
+  void paint(Canvas canvas, Size size) {
+    final paint = Paint()
+      ..color = const Color(0x33111B4B)
+      ..strokeWidth = 1;
+    final spacing = 14.0;
+    for (double x = 18; x < size.width - 16; x += spacing) {
+      canvas.drawLine(Offset(x, 0), Offset(x, size.height), paint);
+    }
+  }
+
+  @override
+  bool shouldRepaint(covariant CustomPainter oldDelegate) => false;
+}
+
+class _ChapterBookmark extends StatelessWidget {
+  const _ChapterBookmark({required this.color, required this.radius});
+
+  final Color color;
+  final Radius radius;
+
+  @override
+  Widget build(BuildContext context) {
+    return Align(
+      alignment: Alignment.centerLeft,
+      child: ClipPath(
+        clipper: _BookmarkClipper(),
+        child: Container(
+          width: double.infinity,
+          decoration: BoxDecoration(
+            color: color.withOpacity(0.92),
+            borderRadius: BorderRadius.only(
+              topRight: radius,
+              bottomRight: radius,
+            ),
+            boxShadow: const [
+              BoxShadow(color: Color(0x22000000), blurRadius: 12, offset: Offset(2, 6)),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _BookmarkClipper extends CustomClipper<Path> {
+  @override
+  Path getClip(Size size) {
+    final path = Path();
+    path.moveTo(0, 4);
+    path.lineTo(size.width - 8, 0);
+    path.lineTo(size.width, size.height * 0.12);
+    path.lineTo(size.width, size.height * 0.88);
+    path.lineTo(size.width - 8, size.height);
+    path.lineTo(0, size.height - 4);
+    path.close();
+    return path;
+  }
+
+  @override
+  bool shouldReclip(covariant CustomClipper<Path> oldClipper) => false;
+}


### PR DESCRIPTION
## Summary
- add ruled notebook viewport, spine tab, and chapter tile widgets for the new overview layout
- build a SpineNotebookView that renders chapters on a shared ruled grid with a hidden add button
- integrate the new overview into BookWorkspaceScreen and remove the old chapter ruler panel

## Testing
- Not run (flutter tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_b_68dbdb9013188322b7f33e159f93c2e9