### PR TITLE
Revamp spine notebook UI with reading mode

### DIFF
--- a/lib/features/book_workspace/reading/chapter_reader_view.dart
+++ b/lib/features/book_workspace/reading/chapter_reader_view.dart
@@ -1,0 +1,112 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+
+import '../../../core/models/chapter.dart';
+
+class ChapterReaderView extends StatelessWidget {
+  const ChapterReaderView({
+    super.key,
+    required this.chapter,
+    required this.onEdit,
+    this.accentColor,
+  });
+
+  final Chapter chapter;
+  final VoidCallback onEdit;
+  final Color? accentColor;
+
+  static const double _maxTextWidth = 720;
+  static const double _minTextWidth = 560;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final effectiveAccent = accentColor ?? const Color(0xFF6366F1);
+    final titleStyle = theme.textTheme.headlineSmall?.copyWith(
+      fontWeight: FontWeight.w700,
+      color: const Color(0xFF0F172A),
+    );
+    final bodyStyle = theme.textTheme.bodyLarge?.copyWith(
+      height: 1.7,
+      fontSize: 18,
+      color: const Color(0xFF0F172A),
+    );
+    final bodyText = chapter.body.isNotEmpty
+        ? chapter.body
+        : chapter.blocks.map((block) => block.text).join('\n\n');
+    final paragraphs = bodyText.isEmpty
+        ? const <String>[]
+        : bodyText.split(RegExp(r'\n{2,}')).where((value) => value.trim().isNotEmpty).toList();
+
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final available = constraints.maxWidth.isFinite
+            ? math.max(0.0, constraints.maxWidth - 64)
+            : _maxTextWidth;
+        final maxWidth = math.min(_maxTextWidth, available);
+        final targetWidth = maxWidth.clamp(_minTextWidth, _maxTextWidth) as double;
+        return Align(
+          alignment: Alignment.topCenter,
+          child: SingleChildScrollView(
+            padding: const EdgeInsets.symmetric(vertical: 32),
+            child: ConstrainedBox(
+              constraints: BoxConstraints(maxWidth: targetWidth),
+              child: DecoratedBox(
+                decoration: BoxDecoration(
+                  color: Colors.white,
+                  borderRadius: BorderRadius.circular(24),
+                  boxShadow: const [
+                    BoxShadow(
+                      color: Color(0x140F172A),
+                      blurRadius: 24,
+                      offset: Offset(0, 12),
+                    ),
+                  ],
+                ),
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 32, vertical: 36),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(chapter.title, style: titleStyle),
+                      if (chapter.subtitle != null && chapter.subtitle!.isNotEmpty) ...[
+                        const SizedBox(height: 8),
+                        Text(
+                          chapter.subtitle!,
+                          style: theme.textTheme.titleMedium?.copyWith(
+                            color: effectiveAccent,
+                            fontWeight: FontWeight.w600,
+                          ),
+                        ),
+                      ],
+                      const SizedBox(height: 24),
+                      for (final paragraph in paragraphs) ...[
+                        Text(paragraph.trim(), style: bodyStyle),
+                        const SizedBox(height: 18),
+                      ],
+                      Align(
+                        alignment: Alignment.centerRight,
+                        child: FilledButton.icon(
+                          onPressed: onEdit,
+                          icon: const Icon(Icons.edit_outlined),
+                          label: const Text('Редактировать'),
+                          style: FilledButton.styleFrom(
+                            backgroundColor: effectiveAccent,
+                            foregroundColor: Colors.white,
+                            padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
+                            shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/features/book_workspace/widgets/top_taskbar.dart
+++ b/lib/features/book_workspace/widgets/top_taskbar.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+
+class TopTaskbar extends StatelessWidget {
+  const TopTaskbar({super.key, required this.onBack, this.actions = const []});
+
+  final VoidCallback onBack;
+  final List<Widget> actions;
+
+  static const Color _background = Color(0xFFF1F5F9);
+  static const Color _accent = Color(0xFF6366F1);
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final iconTheme = theme.iconTheme.copyWith(color: const Color(0xFF334155));
+    return Material(
+      color: Colors.transparent,
+      child: Container(
+        height: 60,
+        padding: const EdgeInsets.symmetric(horizontal: 16),
+        decoration: const BoxDecoration(
+          color: _background,
+          boxShadow: [
+            BoxShadow(
+              color: Color(0x140F172A),
+              blurRadius: 10,
+              offset: Offset(0, 4),
+            ),
+          ],
+        ),
+        child: Row(
+          children: [
+            IconButton(
+              onPressed: onBack,
+              icon: const Icon(Icons.arrow_back),
+              color: _accent,
+            ),
+            const Spacer(),
+            Row(
+              mainAxisSize: MainAxisSize.min,
+              children: actions
+                  .map(
+                    (action) => Padding(
+                      padding: const EdgeInsets.only(left: 8),
+                      child: IconTheme.merge(
+                        data: iconTheme.copyWith(color: _accent),
+                        child: action,
+                      ),
+                    ),
+                  )
+                  .toList(),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- refresh the ruled notebook painter with configurable margin, accent band, and white masks under chapter text
- rebuild the spine notebook list to register text bands, handle collapsed spines, and surface empty slots that create chapters on tap
- add a top taskbar and dedicated chapter reader view while updating the workspace screen to support list, reading, and editing modes

## Testing
- not run (Flutter tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_b_68dbe710bb64832293665018b400b0c8