### PR TITLE
Fix numeric type usage in chapter line tile layout

### DIFF
--- a/lib/features/book_workspace/spine_notebook/chapter_line_tile.dart
+++ b/lib/features/book_workspace/spine_notebook/chapter_line_tile.dart
@@ -67,18 +67,20 @@ class _ChapterLineTileState extends State<ChapterLineTile> {
           );
         }
 
-        final textAreaWidth = math.max(
-          0,
+        final double textAreaWidth = math.max(
+          0.0,
           constraints.maxWidth - widget.spineWidth - ChapterLineTile._horizontalPadding * 2,
         );
 
-        double fontSize = 18;
+        double fontSize = 18.0;
         int linesNeeded = _measureLines(fontSize, textAreaWidth);
         if (linesNeeded > 2) {
-          fontSize = math.max(14, 18 - 1.5 * (linesNeeded - 2));
+          fontSize = math.max(14.0, 18.0 - 1.5 * (linesNeeded - 2));
           linesNeeded = _measureLines(fontSize, textAreaWidth);
         }
-        final lines = math.min(ChapterLineTile._maxLines, math.max(1, linesNeeded));
+        final int lines = math
+            .min(ChapterLineTile._maxLines, math.max(1, linesNeeded))
+            .toInt();
         final rowHeight = lines * widget.lineHeight + ChapterLineTile._verticalPadding;
         final paddingTop = ChapterLineTile._verticalPadding / 2;
 


### PR DESCRIPTION
## Summary
- ensure the text area width used for line measurement is computed as a double
- adjust font sizing math to use double literals and convert the line count back to an int before rendering

## Testing
- Not run (flutter not available in container)


------
https://chatgpt.com/codex/tasks/task_b_68dbedb72fe08322938160f09281c30a