### PR TITLE
Revamp notebook layout with reading mode and taskbar

### DIFF
--- a/lib/features/book_workspace/spine_notebook/chapter_line_tile.dart
+++ b/lib/features/book_workspace/spine_notebook/chapter_line_tile.dart
@@ -2,6 +2,7 @@ import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
 
+import 'spine_constants.dart';
 import 'spine_tab.dart';
 
 class ChapterLineTile extends StatelessWidget {
@@ -13,6 +14,7 @@ class ChapterLineTile extends StatelessWidget {
     required this.active,
     required this.lineHeight,
     required this.spineWidth,
+    this.bandKey,
     required this.onTap,
   });
 
@@ -22,6 +24,7 @@ class ChapterLineTile extends StatelessWidget {
   final bool active;
   final double lineHeight;
   final double spineWidth;
+  final GlobalKey? bandKey;
   final VoidCallback onTap;
 
   @override
@@ -29,7 +32,11 @@ class ChapterLineTile extends StatelessWidget {
     return LayoutBuilder(
       builder: (context, constraints) {
         final availableWidth = constraints.maxWidth;
-        final textMaxWidth = availableWidth - spineWidth - 24 - 32;
+        const double horizontalPadding = 24.0;
+        final textMaxWidth = math.max(
+          0,
+          availableWidth - spineWidth - horizontalPadding * 2,
+        );
 
         int measureLines(double fontSize) {
           final painter = TextPainter(
@@ -38,29 +45,35 @@ class ChapterLineTile extends StatelessWidget {
               style: TextStyle(
                 fontSize: fontSize,
                 fontWeight: FontWeight.w700,
-                height: 1.25,
+                height: 1.2,
                 color: const Color(0xFF0F172A),
               ),
             ),
             textDirection: TextDirection.ltr,
             maxLines: 999,
           );
-          painter.layout(maxWidth: textMaxWidth.clamp(0, double.infinity).toDouble());
+          painter.layout(maxWidth: textMaxWidth.toDouble());
           return painter.computeLineMetrics().length;
         }
 
-        double fontSize = 16;
+        double fontSize = kTitleBase;
         int linesNeeded = measureLines(fontSize);
         if (linesNeeded > 2) {
-          fontSize = math.max(13, 16 - 1.5 * (linesNeeded - 2));
-          linesNeeded = measureLines(fontSize);
+          while (fontSize > kTitleMin && linesNeeded > kTabMaxLines) {
+            fontSize = math.max(kTitleMin, fontSize - 1);
+            linesNeeded = measureLines(fontSize);
+          }
+          if (linesNeeded > kTabMaxLines) {
+            linesNeeded = kTabMaxLines;
+          }
         }
-        final int lines = linesNeeded.clamp(1, 4) as int;
+        final int lines = linesNeeded.clamp(kTabMinLines, kTabMaxLines);
         final rowHeight = lines * lineHeight;
 
         return Padding(
-          padding: const EdgeInsets.symmetric(vertical: 4),
+          padding: const EdgeInsets.symmetric(vertical: 3),
           child: SizedBox(
+            key: bandKey,
             height: rowHeight,
             child: Row(
               crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -84,21 +97,24 @@ class ChapterLineTile extends StatelessWidget {
                     onTap: onTap,
                     borderRadius: BorderRadius.circular(8),
                     child: Padding(
-                      padding: const EdgeInsets.symmetric(horizontal: 16),
-                      child: Align(
-                        alignment: Alignment.centerLeft,
-                        child: Text(
-                          title,
-                          maxLines: lines,
-                          overflow: TextOverflow.ellipsis,
-                          softWrap: true,
-                          style: TextStyle(
-                            fontSize: fontSize,
-                            fontWeight: FontWeight.w700,
-                            height: 1.25,
-                            color: const Color(0xFF0F172A),
+                      padding: const EdgeInsets.symmetric(horizontal: horizontalPadding),
+                      child: Column(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            title,
+                            maxLines: lines,
+                            overflow: TextOverflow.ellipsis,
+                            softWrap: true,
+                            style: TextStyle(
+                              fontSize: fontSize,
+                              fontWeight: FontWeight.w700,
+                              height: 1.2,
+                              color: const Color(0xFF0F172A),
+                            ),
                           ),
-                        ),
+                        ],
                       ),
                     ),
                   ),

--- a/lib/features/book_workspace/spine_notebook/chapter_reader_view.dart
+++ b/lib/features/book_workspace/spine_notebook/chapter_reader_view.dart
@@ -1,0 +1,291 @@
+import 'dart:math' as math;
+import 'dart:ui';
+
+import 'package:flutter/material.dart';
+
+import 'package:voicebook/core/models/chapter.dart';
+
+import 'ruled_viewport.dart';
+import 'spine_constants.dart';
+import 'spine_palette.dart';
+
+class ChapterReaderView extends StatefulWidget {
+  const ChapterReaderView({
+    super.key,
+    required this.chapter,
+    required this.onEdit,
+  });
+
+  final Chapter chapter;
+  final VoidCallback onEdit;
+
+  @override
+  State<ChapterReaderView> createState() => _ChapterReaderViewState();
+}
+
+class _ChapterReaderViewState extends State<ChapterReaderView> {
+  final ScrollController _controller = ScrollController();
+  final GlobalKey _stackKey = GlobalKey();
+  final GlobalKey _headerKey = GlobalKey();
+  final GlobalKey _bodyKey = GlobalKey();
+  final ValueNotifier<List<Rect>> _bands = ValueNotifier<List<Rect>>(<Rect>[]);
+  bool _bandsDirty = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller.addListener(_scheduleBands);
+    WidgetsBinding.instance.addPostFrameCallback((_) => _collectBands());
+  }
+
+  @override
+  void dispose() {
+    _controller.removeListener(_scheduleBands);
+    _controller.dispose();
+    _bands.dispose();
+    super.dispose();
+  }
+
+  @override
+  void didUpdateWidget(covariant ChapterReaderView oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.chapter.id != widget.chapter.id || oldWidget.chapter.body != widget.chapter.body) {
+      _scheduleBands();
+    }
+  }
+
+  void _scheduleBands() {
+    if (_bandsDirty) {
+      return;
+    }
+    _bandsDirty = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) {
+        return;
+      }
+      _bandsDirty = false;
+      _collectBands();
+    });
+  }
+
+  void _collectBands() {
+    final RenderBox? stackBox = _stackKey.currentContext?.findRenderObject() as RenderBox?;
+    if (stackBox == null) {
+      return;
+    }
+    final double width = stackBox.size.width;
+    final double left = kCollapsedSpineWidth;
+    final double right = math.max(left, width - kRightMarginOffset);
+    final double bandWidth = right - left;
+    final List<Rect> result = <Rect>[];
+
+    void addBand(GlobalKey key) {
+      final RenderBox? box = key.currentContext?.findRenderObject() as RenderBox?;
+      if (box == null) {
+        return;
+      }
+      final Offset offset = box.localToGlobal(Offset.zero, ancestor: stackBox);
+      final Size size = box.size;
+      if (size.height <= 0) {
+        return;
+      }
+      final double inset = math.min(12.0, size.height * 0.15);
+      final Rect rect = Rect.fromLTRB(
+        left,
+        offset.dy + inset,
+        left + bandWidth,
+        offset.dy + size.height - inset,
+      );
+      if (rect.bottom > rect.top) {
+        result.add(rect);
+      }
+    }
+
+    addBand(_headerKey);
+    addBand(_bodyKey);
+
+    _bands.value = result;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final chapter = widget.chapter;
+    final Color accentColor = spineAccentFor(chapter.id);
+    final TextTheme textTheme = Theme.of(context).textTheme;
+    final EdgeInsets contentPadding = const EdgeInsets.symmetric(horizontal: 32, vertical: 24);
+    final double horizontalInset = kCollapsedSpineWidth + 24;
+
+    return Stack(
+      key: _stackKey,
+      children: [
+        ValueListenableBuilder<List<Rect>>(
+          valueListenable: _bands,
+          builder: (context, bands, child) {
+            return RuledViewport(
+              controller: _controller,
+              spineWidth: kCollapsedSpineWidth,
+              accentColor: accentColor,
+              textBands: bands,
+              child: child!,
+            );
+          },
+          child: ListView(
+            controller: _controller,
+            padding: EdgeInsets.only(bottom: 96),
+            children: [
+              Padding(
+                key: _headerKey,
+                padding: EdgeInsets.fromLTRB(horizontalInset, 40, contentPadding.right, 24),
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Hero(
+                            tag: 'chapter_title_${chapter.id}',
+                            child: Material(
+                              color: Colors.transparent,
+                              child: Text(
+                                chapter.title,
+                                style: textTheme.headlineSmall?.copyWith(
+                                  fontWeight: FontWeight.w700,
+                                  color: const Color(0xFF0F172A),
+                                ),
+                              ),
+                            ),
+                          ),
+                          if ((chapter.subtitle ?? '').isNotEmpty)
+                            Padding(
+                              padding: const EdgeInsets.only(top: 8),
+                              child: Text(
+                                chapter.subtitle!,
+                                style: textTheme.titleMedium?.copyWith(color: const Color(0xFF475569)),
+                              ),
+                            ),
+                        ],
+                      ),
+                    ),
+                    const SizedBox(width: 24),
+                    FilledButton.tonal(
+                      onPressed: widget.onEdit,
+                      child: const Text('Редактировать'),
+                    ),
+                  ],
+                ),
+              ),
+              Padding(
+                key: _bodyKey,
+                padding: EdgeInsets.fromLTRB(horizontalInset, 0, contentPadding.right, 40),
+                child: _ChapterBody(chapter: chapter),
+              ),
+            ],
+          ),
+        ),
+        Positioned(
+          left: 0,
+          top: 0,
+          bottom: 0,
+          width: kCollapsedSpineWidth,
+          child: IgnorePointer(
+            child: DecoratedBox(
+              decoration: BoxDecoration(
+                gradient: LinearGradient(
+                  begin: Alignment.topCenter,
+                  end: Alignment.bottomCenter,
+                  colors: [
+                    const Color(0xFF312E81).withOpacity(0.85),
+                    const Color(0xFF5B21B6).withOpacity(0.85),
+                  ],
+                ),
+                boxShadow: const [
+                  BoxShadow(color: Color(0x33000000), blurRadius: 12, offset: Offset(0, 4)),
+                ],
+              ),
+              child: const _SpineSlices(),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _ChapterBody extends StatelessWidget {
+  const _ChapterBody({required this.chapter});
+
+  final Chapter chapter;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final bodyText = chapter.body.trim();
+    if (bodyText.isEmpty) {
+      return Container(
+        padding: const EdgeInsets.all(24),
+        decoration: BoxDecoration(
+          color: Colors.white.withOpacity(0.82),
+          borderRadius: BorderRadius.circular(18),
+          boxShadow: const [
+            BoxShadow(color: Color(0x140F172A), blurRadius: 18, offset: Offset(0, 6)),
+          ],
+        ),
+        child: Text(
+          'Пока нет текста. Нажмите «Редактировать», чтобы начать работу над главой.',
+          style: theme.textTheme.bodyLarge?.copyWith(color: const Color(0xFF64748B)),
+        ),
+      );
+    }
+
+    final paragraphs = bodyText.split(RegExp(r'\n{2,}'));
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        for (int i = 0; i < paragraphs.length; i += 1)
+          Padding(
+            padding: EdgeInsets.only(bottom: i == paragraphs.length - 1 ? 0 : 18),
+            child: Text(
+              paragraphs[i].trim(),
+              style: theme.textTheme.bodyLarge?.copyWith(
+                height: 1.5,
+                color: const Color(0xFF1E293B),
+              ),
+            ),
+          ),
+      ],
+    );
+  }
+}
+
+class _SpineSlices extends StatelessWidget {
+  const _SpineSlices();
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        const double sliceHeight = kLineHeight;
+        final int slices = (constraints.maxHeight / sliceHeight).ceil();
+        return Column(
+          children: [
+            for (int i = 0; i < slices; i += 1)
+              Expanded(
+                child: Align(
+                  alignment: Alignment.centerLeft,
+                  child: Container(
+                    margin: const EdgeInsets.symmetric(vertical: 2, horizontal: 4),
+                    width: 12,
+                    decoration: BoxDecoration(
+                      color: Colors.white.withOpacity(i.isEven ? 0.12 : 0.18),
+                      borderRadius: BorderRadius.circular(8),
+                    ),
+                  ),
+                ),
+              ),
+          ],
+        );
+      },
+    );
+  }
+}

--- a/lib/features/book_workspace/spine_notebook/spine_constants.dart
+++ b/lib/features/book_workspace/spine_notebook/spine_constants.dart
@@ -1,0 +1,8 @@
+const double kLineHeight = 28.0;
+const double kSpineWidth = 112.0;
+const double kCollapsedSpineWidth = 24.0;
+const double kRightMarginOffset = 32.0;
+const int kTabMinLines = 1;
+const int kTabMaxLines = 4;
+const double kTitleBase = 18.0;
+const double kTitleMin = 14.0;

--- a/lib/features/book_workspace/spine_notebook/spine_notebook_view.dart
+++ b/lib/features/book_workspace/spine_notebook/spine_notebook_view.dart
@@ -1,11 +1,16 @@
 import 'dart:async';
+import 'dart:math' as math;
+import 'dart:ui';
 
+import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 
 import 'package:voicebook/core/models/chapter_summary.dart';
 
 import 'chapter_line_tile.dart';
 import 'ruled_viewport.dart';
+import 'spine_constants.dart';
+import 'spine_palette.dart';
 import 'spine_tab.dart';
 
 class SpineNotebookView extends StatefulWidget {
@@ -29,17 +34,20 @@ class SpineNotebookView extends StatefulWidget {
 }
 
 class _SpineNotebookViewState extends State<SpineNotebookView> {
-  static const double _lineHeight = 28;
-  static const double _spineWidth = 104;
-
   final ScrollController _controller = ScrollController();
   bool _showAddButton = false;
   Timer? _revealTimer;
+  final ValueNotifier<List<Rect>> _textBands = ValueNotifier<List<Rect>>(<Rect>[]);
+  final GlobalKey _stackKey = GlobalKey();
+  final GlobalKey _headerBandKey = GlobalKey();
+  final Map<String, GlobalKey> _chapterBandKeys = <String, GlobalKey>{};
+  bool _bandsDirty = false;
 
   @override
   void initState() {
     super.initState();
     _controller.addListener(_handleScroll);
+    WidgetsBinding.instance.addPostFrameCallback((_) => _collectTextBands());
   }
 
   @override
@@ -47,7 +55,22 @@ class _SpineNotebookViewState extends State<SpineNotebookView> {
     _revealTimer?.cancel();
     _controller.removeListener(_handleScroll);
     _controller.dispose();
+    _textBands.dispose();
     super.dispose();
+  }
+
+  @override
+  void didUpdateWidget(covariant SpineNotebookView oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (!const ListEquality<String>().equals(
+      oldWidget.chapters.map((chapter) => chapter.id).toList(),
+      widget.chapters.map((chapter) => chapter.id).toList(),
+    )) {
+      _syncChapterKeys();
+      _scheduleBandCollection();
+    } else if (oldWidget.bookTitle != widget.bookTitle) {
+      _scheduleBandCollection();
+    }
   }
 
   void _handleScroll() {
@@ -58,6 +81,7 @@ class _SpineNotebookViewState extends State<SpineNotebookView> {
         _setAddVisibility(true);
       }
     });
+    _scheduleBandCollection();
   }
 
   void _setAddVisibility(bool visible) {
@@ -74,16 +98,99 @@ class _SpineNotebookViewState extends State<SpineNotebookView> {
     }
   }
 
+  void _syncChapterKeys() {
+    final Map<String, GlobalKey> updated = <String, GlobalKey>{};
+    for (final chapter in widget.chapters) {
+      updated[chapter.id] = _chapterBandKeys[chapter.id] ?? GlobalKey();
+    }
+    _chapterBandKeys
+      ..clear()
+      ..addAll(updated);
+  }
+
+  void _scheduleBandCollection() {
+    if (_bandsDirty) {
+      return;
+    }
+    _bandsDirty = true;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) {
+        return;
+      }
+      _bandsDirty = false;
+      _collectTextBands();
+    });
+  }
+
+  void _collectTextBands() {
+    final RenderBox? stackBox = _stackKey.currentContext?.findRenderObject() as RenderBox?;
+    if (stackBox == null) {
+      return;
+    }
+    final double width = stackBox.size.width;
+    final double left = kSpineWidth;
+    final double right = math.max(left, width - kRightMarginOffset);
+    final double maxWidth = right - left;
+    final List<Rect> bands = <Rect>[];
+
+    void addBand(GlobalKey key) {
+      final RenderBox? renderBox = key.currentContext?.findRenderObject() as RenderBox?;
+      if (renderBox == null) {
+        return;
+      }
+      final Offset origin = renderBox.localToGlobal(Offset.zero, ancestor: stackBox);
+      final double bandHeight = renderBox.size.height;
+      if (bandHeight <= 0) {
+        return;
+      }
+      final Rect baseRect = Rect.fromLTWH(left, origin.dy, maxWidth, bandHeight);
+      final double inset = math.min(6.0, bandHeight / 3);
+      final Rect clipped = Rect.fromLTRB(
+        baseRect.left,
+        baseRect.top + inset,
+        baseRect.right,
+        baseRect.bottom - inset,
+      );
+      if (clipped.bottom > clipped.top) {
+        bands.add(clipped);
+      }
+    }
+
+    addBand(_headerBandKey);
+    for (final chapter in widget.chapters) {
+      final key = _chapterBandKeys[chapter.id];
+      if (key != null) {
+        addBand(key);
+      }
+    }
+
+    bands.sort((a, b) => a.top.compareTo(b.top));
+    _textBands.value = bands;
+  }
+
   @override
   Widget build(BuildContext context) {
     final chapters = widget.chapters;
+    _syncChapterKeys();
+    _scheduleBandCollection();
 
     return Stack(
+      key: _stackKey,
       children: [
-        RuledViewport(
-          controller: _controller,
-          lineHeight: _lineHeight,
-          spineWidth: _spineWidth,
+        ValueListenableBuilder<List<Rect>>(
+          valueListenable: _textBands,
+          builder: (context, bands, child) {
+            final accentId = widget.activeId;
+            final Color accentColor = accentId != null
+                ? spineAccentFor(accentId)
+                : const Color(0xFF38BDF8);
+            return RuledViewport(
+              controller: _controller,
+              child: child!,
+              accentColor: accentColor,
+              textBands: bands,
+            );
+          },
           child: ListView.builder(
             controller: _controller,
             padding: const EdgeInsets.only(bottom: 120),
@@ -91,20 +198,24 @@ class _SpineNotebookViewState extends State<SpineNotebookView> {
             itemBuilder: (context, index) {
               if (index == 0) {
                 return _NotebookHeader(
+                  key: _headerBandKey,
                   title: widget.bookTitle,
-                  lineHeight: _lineHeight,
-                  spineWidth: _spineWidth,
+                  lineHeight: kLineHeight,
+                  spineWidth: kSpineWidth,
                 );
               }
               final chapter = chapters[index - 1];
               final isActive = chapter.id == widget.activeId;
+              final bandKey = _chapterBandKeys[chapter.id] ?? GlobalKey();
+              _chapterBandKeys[chapter.id] = bandKey;
               return ChapterLineTile(
+                bandKey: bandKey,
                 index: index,
                 title: chapter.title,
-                color: _colorFor(chapter.id),
+                color: spineAccentFor(chapter.id),
                 active: isActive,
-                lineHeight: _lineHeight,
-                spineWidth: _spineWidth,
+                lineHeight: kLineHeight,
+                spineWidth: kSpineWidth,
                 onTap: () => widget.onOpen(chapter.id),
               );
             },
@@ -114,7 +225,7 @@ class _SpineNotebookViewState extends State<SpineNotebookView> {
           left: 0,
           top: 0,
           bottom: 0,
-          width: _spineWidth,
+          width: kSpineWidth,
           child: MouseRegion(
             onEnter: (_) => _handlePointerHover(true),
             onExit: (_) => _handlePointerHover(false),
@@ -134,7 +245,7 @@ class _SpineNotebookViewState extends State<SpineNotebookView> {
               curve: Curves.easeOutCubic,
               child: IgnorePointer(
                 ignoring: !_showAddButton,
-                child: _GhostAddTab(lineHeight: _lineHeight),
+                child: _GhostAddTab(lineHeight: kLineHeight),
               ),
             ),
           ),
@@ -169,6 +280,7 @@ class _GhostAddTab extends StatelessWidget {
 
 class _NotebookHeader extends StatelessWidget {
   const _NotebookHeader({
+    super.key,
     required this.title,
     required this.lineHeight,
     required this.spineWidth,
@@ -189,7 +301,7 @@ class _NotebookHeader extends StatelessWidget {
           SizedBox(width: spineWidth),
           Expanded(
             child: Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 16),
+              padding: const EdgeInsets.symmetric(horizontal: 24),
               child: Align(
                 alignment: Alignment.bottomLeft,
                 child: Text(
@@ -210,23 +322,3 @@ class _NotebookHeader extends StatelessWidget {
   }
 }
 
-const List<Color> _pastelPalette = <Color>[
-  Color(0xFFE8E7FE),
-  Color(0xFFEDE6FB),
-  Color(0xFFE6FAFD),
-  Color(0xFFEFFBF2),
-  Color(0xFFFFF3E4),
-  Color(0xFFFFE9ED),
-  Color(0xFFE6F0FF),
-  Color(0xFFEAF7FF),
-  Color(0xFFF2E7FF),
-  Color(0xFFE7FFF6),
-];
-
-Color _colorFor(String id) {
-  if (id.isEmpty) {
-    return _pastelPalette.first;
-  }
-  final hash = id.codeUnits.fold<int>(0, (acc, unit) => (acc * 31 + unit) & 0x7fffffff);
-  return _pastelPalette[hash % _pastelPalette.length];
-}

--- a/lib/features/book_workspace/spine_notebook/spine_palette.dart
+++ b/lib/features/book_workspace/spine_notebook/spine_palette.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+
+const List<Color> kSpinePastelPalette = <Color>[
+  Color(0xFFE8E7FE),
+  Color(0xFFEDE6FB),
+  Color(0xFFE6FAFD),
+  Color(0xFFEFFBF2),
+  Color(0xFFFFF3E4),
+  Color(0xFFFFE9ED),
+  Color(0xFFE6F0FF),
+  Color(0xFFEAF7FF),
+  Color(0xFFF2E7FF),
+  Color(0xFFE7FFF6),
+];
+
+Color spineAccentFor(String id) {
+  if (id.isEmpty) {
+    return kSpinePastelPalette.first;
+  }
+  final int hash = id.codeUnits.fold<int>(0, (acc, unit) => (acc * 31 + unit) & 0x7fffffff);
+  return kSpinePastelPalette[hash % kSpinePastelPalette.length];
+}

--- a/lib/features/book_workspace/spine_notebook/spine_tab.dart
+++ b/lib/features/book_workspace/spine_notebook/spine_tab.dart
@@ -3,6 +3,8 @@ import 'dart:ui';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
+import 'spine_constants.dart';
+
 class SpineTab extends StatefulWidget {
   const SpineTab({
     super.key,
@@ -21,8 +23,8 @@ class SpineTab extends StatefulWidget {
   final bool active;
   final VoidCallback onTap;
 
-  static const double baseWidth = 104;
-  static const double hoverWidth = 132;
+  static const double baseWidth = kSpineWidth;
+  static const double hoverWidth = kSpineWidth;
 
   @override
   State<SpineTab> createState() => _SpineTabState();
@@ -45,7 +47,7 @@ class _SpineTabState extends State<SpineTab> {
   Widget build(BuildContext context) {
     final height = widget.lines * widget.lineHeight;
     final radius = Radius.circular(20);
-    final width = _hovered ? SpineTab.hoverWidth : SpineTab.baseWidth;
+    final width = SpineTab.baseWidth;
 
     final decoration = BoxDecoration(
       gradient: const LinearGradient(
@@ -68,7 +70,7 @@ class _SpineTabState extends State<SpineTab> {
     );
 
     final badge = Container(
-      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
       decoration: BoxDecoration(
         color: Colors.black.withOpacity(0.36),
         borderRadius: BorderRadius.circular(12),
@@ -153,15 +155,7 @@ class _SpineTabState extends State<SpineTab> {
                   ),
               ),
             ),
-            Positioned.fill(
-              child: Padding(
-                padding: const EdgeInsets.only(left: 16, right: 20),
-                child: Align(
-                  alignment: Alignment.center,
-                  child: badge,
-                ),
-              ),
-            ),
+            Center(child: badge),
           ],
         ),
       ),

--- a/lib/features/book_workspace/widgets/top_taskbar.dart
+++ b/lib/features/book_workspace/widgets/top_taskbar.dart
@@ -1,0 +1,116 @@
+import 'package:flutter/material.dart';
+
+import '../../../core/models/chapter.dart';
+
+class TopTaskbar extends StatelessWidget {
+  const TopTaskbar({
+    super.key,
+    required this.title,
+    required this.isListMode,
+    required this.activeChapter,
+    required this.onBack,
+    required this.onShowList,
+    required this.onExport,
+    required this.onOpenSettings,
+  });
+
+  final String title;
+  final bool isListMode;
+  final Chapter? activeChapter;
+  final VoidCallback onBack;
+  final VoidCallback onShowList;
+  final VoidCallback onExport;
+  final VoidCallback onOpenSettings;
+
+  @override
+  Widget build(BuildContext context) {
+    final textTheme = Theme.of(context).textTheme;
+    final Color baseTextColor = const Color(0xFF0F172A);
+    return Material(
+      color: const Color(0xFFF1F5F9),
+      elevation: 0,
+      child: Container(
+        decoration: const BoxDecoration(
+          color: Color(0xFFF1F5F9),
+          boxShadow: [
+            BoxShadow(color: Color(0x1A000000), blurRadius: 24, offset: Offset(0, 4)),
+          ],
+        ),
+        child: SafeArea(
+          bottom: false,
+          child: SizedBox(
+            height: 60,
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 24),
+              child: Row(
+                children: [
+                  TextButton.icon(
+                    onPressed: onBack,
+                    style: TextButton.styleFrom(
+                      foregroundColor: const Color(0xFF1E293B),
+                      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+                      backgroundColor: Colors.white,
+                      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(14)),
+                    ),
+                    icon: const Icon(Icons.arrow_back_ios_new_rounded, size: 18),
+                    label: const Text('Назад'),
+                  ),
+                  const SizedBox(width: 24),
+                  Expanded(
+                    child: Column(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          title,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: textTheme.titleLarge?.copyWith(
+                            fontWeight: FontWeight.w700,
+                            color: baseTextColor,
+                          ),
+                        ),
+                        if (!isListMode && activeChapter != null)
+                          Text(
+                            activeChapter!.title,
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                            style: textTheme.bodyMedium?.copyWith(color: const Color(0xFF475569)),
+                          ),
+                      ],
+                    ),
+                  ),
+                  if (!isListMode)
+                    Padding(
+                      padding: const EdgeInsets.only(right: 12),
+                      child: OutlinedButton.icon(
+                        onPressed: onShowList,
+                        style: OutlinedButton.styleFrom(
+                          foregroundColor: const Color(0xFF1D4ED8),
+                          side: const BorderSide(color: Color(0xFFBFDBFE)),
+                          padding: const EdgeInsets.symmetric(horizontal: 18, vertical: 12),
+                          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(14)),
+                        ),
+                        icon: const Icon(Icons.menu_book_outlined),
+                        label: const Text('Оглавление'),
+                      ),
+                    ),
+                  IconButton(
+                    tooltip: 'Экспорт',
+                    onPressed: onExport,
+                    icon: const Icon(Icons.ios_share_outlined),
+                  ),
+                  IconButton(
+                    tooltip: 'Настройки',
+                    onPressed: onOpenSettings,
+                    icon: const Icon(Icons.settings_outlined),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- refactor the spine notebook background to honor fixed metrics, margin stripes, and masked text lanes
- add a dedicated reader experience with collapsed spine stubs and a reusable taskbar for navigation and actions
- update notebook rows, spine tabs, and workspace mode handling to support the new layout constants and reading/editing flow

## Testing
- Not run (flutter tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_b_68dbf5ac72188322baae87c73f5828f5