### PR TITLE
Add book outline route and connect workspace navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,10 @@ lib/
 | Route | Экран | Переход | Примечание |
 | --- | --- | --- | --- |
 | `/onboarding` | Onboarding / Permissions | Fade → Library | Гард перенаправит обратно, если не выданы все разрешения. |
-| `/library` | Library | Default | Карточки книг открывают рабочее пространство, меню ведёт в экспорт. |
-| `/book/:bookId` | Book Workspace | Slide from right | Содержит линейку глав, редактор и панель действий. |
-| `/book/:bookId/structure` | Mindmap Modal | Fade + Scale | Модальное дерево сцен поверх workspace. |
+| `/library` | Library | Default | Карточки книг открывают оглавление, меню ведёт в экспорт. |
+| `/book/:bookId` | Book Outline | Slide from right | Витрина книги: биллинг, мета, прогресс и список глав. |
+| `/book/:bookId/editor` | Book Workspace | Slide from right | Содержит линейку глав, редактор и панель действий. |
+| `/book/:bookId/editor/structure` | Mindmap Modal | Fade + Scale | Модальное дерево сцен поверх workspace. |
 | `/ai/composer` | AI Composer Drawer | Slide from right | Открывается как выезжающий сайдбар. |
 | `/voice/training` | Voice Training | Slide | Используется, если профиль голоса не готов. |
 | `/export` | Export | Slide up | Требует `bookId`, иначе редиректит в библиотеку. |

--- a/docs/ui_components.md
+++ b/docs/ui_components.md
@@ -18,8 +18,9 @@
 |-------|------|--------------------------------|----------|
 | Онбординг | `/onboarding` | – | После подтверждения разрешений → `/library` |
 | Библиотека | `/library` | – | Tap по книге → `/book/:bookId` |
-| Рабочее пространство | `/book/:bookId` | `structure` (modal), `ai/composer` (drawer), `export?bookId`, `voice/training`, `settings` | Из FAB-панели и шапки |
-| Mindmap | `/book/:bookId/structure?chapterId=` | `state.extra` — `List<SceneNode>` | Открывается из кнопки «Структура» |
+| Оглавление книги | `/book/:bookId` | `editor`, `editor/structure` | Содержит биллинг, мета-блок и список глав |
+| Рабочее пространство | `/book/:bookId/editor` | `structure` (modal), `ai/composer` (drawer), `export?bookId`, `voice/training`, `settings` | Из FAB-панели и шапки |
+| Mindmap | `/book/:bookId/editor/structure?chapterId=` | `state.extra` — `List<SceneNode>` | Открывается из кнопки «Структура» |
 | AI-Composer | `/ai/composer` | Drawer-панель | Жест/кнопка «Сформировать текст» |
 | Тренировка голоса | `/voice/training` | – | FAB → «Озвучить» без профиля |
 | Экспорт | `/export?bookId=` | – | Меню книги или FAB → «Экспорт» |

--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -4,6 +4,7 @@ import 'package:go_router/go_router.dart';
 
 import 'package:voicebook/core/providers/app_providers.dart';
 import 'package:voicebook/features/ai_composer/ai_composer_drawer.dart';
+import 'package:voicebook/features/book_outline/book_outline_screen.dart';
 import 'package:voicebook/features/book_workspace/book_workspace_screen.dart';
 import 'package:voicebook/features/export/export_screen.dart';
 import 'package:voicebook/features/library/library_screen.dart';
@@ -58,7 +59,7 @@ final appRouterProvider = Provider<GoRouter>((ref) {
           final bookId = state.pathParameters['bookId']!;
           return CustomTransitionPage(
             key: state.pageKey,
-            child: BookWorkspaceScreen(bookId: bookId),
+            child: BookOutlineScreen(bookId: bookId),
             transitionsBuilder: (context, animation, secondaryAnimation, child) {
               final tween = Tween<Offset>(begin: const Offset(1, 0), end: Offset.zero)
                   .chain(CurveTween(curve: Curves.easeOutCubic));
@@ -68,27 +69,45 @@ final appRouterProvider = Provider<GoRouter>((ref) {
         },
         routes: [
           GoRoute(
-            parentNavigatorKey: _rootNavigatorKey,
-            path: 'structure',
-            name: 'mindmap',
+            path: 'editor',
+            name: 'bookEditor',
             pageBuilder: (context, state) {
               final bookId = state.pathParameters['bookId']!;
-              final fallbackChapterId = ref.read(currentChapterIdProvider(bookId));
-              final chapterId = state.uri.queryParameters['chapterId'] ?? fallbackChapterId;
               return CustomTransitionPage(
                 key: state.pageKey,
-                barrierDismissible: true,
-                barrierColor: Colors.black54,
-                opaque: false,
-                child: StructureMindmapScreen(bookId: bookId, chapterId: chapterId),
+                child: BookWorkspaceScreen(bookId: bookId),
                 transitionsBuilder: (context, animation, secondaryAnimation, child) {
-                  return FadeTransition(
-                    opacity: animation,
-                    child: ScaleTransition(scale: Tween(begin: 0.98, end: 1.0).animate(animation), child: child),
-                  );
+                  final tween = Tween<Offset>(begin: const Offset(1, 0), end: Offset.zero)
+                      .chain(CurveTween(curve: Curves.easeOutCubic));
+                  return SlideTransition(position: animation.drive(tween), child: child);
                 },
               );
             },
+            routes: [
+              GoRoute(
+                parentNavigatorKey: _rootNavigatorKey,
+                path: 'structure',
+                name: 'mindmap',
+                pageBuilder: (context, state) {
+                  final bookId = state.pathParameters['bookId']!;
+                  final fallbackChapterId = ref.read(currentChapterIdProvider(bookId));
+                  final chapterId = state.uri.queryParameters['chapterId'] ?? fallbackChapterId;
+                  return CustomTransitionPage(
+                    key: state.pageKey,
+                    barrierDismissible: true,
+                    barrierColor: Colors.black54,
+                    opaque: false,
+                    child: StructureMindmapScreen(bookId: bookId, chapterId: chapterId),
+                    transitionsBuilder: (context, animation, secondaryAnimation, child) {
+                      return FadeTransition(
+                        opacity: animation,
+                        child: ScaleTransition(scale: Tween(begin: 0.98, end: 1.0).animate(animation), child: child),
+                      );
+                    },
+                  );
+                },
+              ),
+            ],
           ),
         ],
       ),

--- a/lib/features/book_outline/book_outline_screen.dart
+++ b/lib/features/book_outline/book_outline_screen.dart
@@ -1,0 +1,180 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import 'package:voicebook/core/models/chapter.dart' as domain;
+import 'package:voicebook/core/models/notebook.dart';
+import 'package:voicebook/core/providers/app_providers.dart';
+import 'package:voicebook/core/storage/ui_state_storage.dart';
+import 'package:voicebook/models/chapter.dart' as outline;
+import 'package:voicebook/models/work.dart';
+import 'package:voicebook/views/notebook_outline_view.dart';
+
+class BookOutlineScreen extends ConsumerWidget {
+  const BookOutlineScreen({super.key, required this.bookId});
+
+  final String bookId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final notebook = ref.watch(bookProvider(bookId));
+    final chapters = ref.watch(bookChaptersProvider(bookId));
+
+    if (notebook == null) {
+      return const Scaffold(
+        appBar: AppBar(),
+        body: Center(child: Text('Коллекция не найдена.')),
+      );
+    }
+
+    final work = _mapNotebookToWork(notebook);
+    final outlineChapters = chapters.map(_mapChapter).toList();
+    final firstChapterId = outlineChapters.isNotEmpty ? outlineChapters.first.id : null;
+
+    void openWorkspace({String? chapterId, _OutlineWorkspaceIntent intent = _OutlineWorkspaceIntent.list}) {
+      _prepareWorkspace(ref, bookId: bookId, chapterId: chapterId, intent: intent);
+      context.pushNamed('bookEditor', pathParameters: {'bookId': bookId});
+    }
+
+    void openMindmap({String? chapterId}) {
+      _prepareWorkspace(ref, bookId: bookId, chapterId: chapterId, intent: _OutlineWorkspaceIntent.list);
+      context.pushNamed(
+        'mindmap',
+        pathParameters: {'bookId': bookId},
+        queryParameters: {
+          if (chapterId != null) 'chapterId': chapterId,
+        },
+      );
+    }
+
+    return NotebookOutlineView(
+      work: work,
+      chapters: outlineChapters,
+      onDictate: () => openWorkspace(chapterId: firstChapterId, intent: _OutlineWorkspaceIntent.edit),
+      onEdit: () => openWorkspace(chapterId: firstChapterId, intent: _OutlineWorkspaceIntent.edit),
+      onOpenMap: work.isMindmap ? () => openMindmap(chapterId: firstChapterId) : null,
+      onAddNode: work.isMindmap ? () => openMindmap(chapterId: firstChapterId) : null,
+      onMore: () {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Скоро добавим дополнительные действия.')),
+        );
+      },
+      onReadChapter: (chapter) => openWorkspace(chapterId: chapter.id, intent: _OutlineWorkspaceIntent.reading),
+      onEditChapter: (chapter) => openWorkspace(chapterId: chapter.id, intent: _OutlineWorkspaceIntent.edit),
+      onVoiceChapter: (chapter) => openWorkspace(chapterId: chapter.id, intent: _OutlineWorkspaceIntent.edit),
+      onOpenChapter: (chapter) => openWorkspace(chapterId: chapter.id, intent: _OutlineWorkspaceIntent.reading),
+    );
+  }
+}
+
+enum _OutlineWorkspaceIntent { list, reading, edit }
+
+void _prepareWorkspace(
+  WidgetRef ref, {
+  required String bookId,
+  String? chapterId,
+  _OutlineWorkspaceIntent intent = _OutlineWorkspaceIntent.list,
+}) {
+  if (chapterId != null) {
+    ref.read(currentChapterIdProvider(bookId).notifier).state = chapterId;
+  }
+
+  unawaited(_persistWorkspaceIntent(bookId: bookId, chapterId: chapterId, intent: intent));
+}
+
+Future<void> _persistWorkspaceIntent({
+  required String bookId,
+  String? chapterId,
+  _OutlineWorkspaceIntent intent = _OutlineWorkspaceIntent.list,
+}) async {
+  final storage = await UiStateStorage.open();
+  final raw = _encodeIntent(intent, chapterId: chapterId);
+  await storage.writeWorkspaceMode(bookId, raw);
+}
+
+String _encodeIntent(_OutlineWorkspaceIntent intent, {String? chapterId}) {
+  switch (intent) {
+    case _OutlineWorkspaceIntent.list:
+      return 'list';
+    case _OutlineWorkspaceIntent.reading:
+      return chapterId != null ? 'reading::$chapterId' : 'list';
+    case _OutlineWorkspaceIntent.edit:
+      return chapterId != null ? 'edit::$chapterId' : 'list';
+  }
+}
+
+Work _mapNotebookToWork(Notebook notebook) {
+  final type = _resolveWorkType(notebook);
+  return Work(
+    id: notebook.id,
+    title: notebook.title,
+    type: type,
+    tags: notebook.tags,
+    words: notebook.words,
+    sections: notebook.chapters,
+    updatedAt: notebook.updatedAt,
+    icon: type == WorkType.mindmap ? Icons.account_tree_outlined : Icons.menu_book_outlined,
+  );
+}
+
+WorkType _resolveWorkType(Notebook notebook) {
+  final normalized = notebook.tags.map((tag) => tag.toLowerCase()).toList();
+  if (normalized.any((tag) => tag.contains('mindmap') || tag.contains('майнд') || tag.contains('карта'))) {
+    return WorkType.mindmap;
+  }
+  return WorkType.book;
+}
+
+outline.Chapter _mapChapter(domain.Chapter chapter) {
+  return outline.Chapter(
+    id: chapter.id,
+    title: chapter.title,
+    words: _resolveWordCount(chapter),
+    status: _mapChapterStatus(chapter.status),
+    excerpt: _buildExcerpt(chapter),
+  );
+}
+
+int _resolveWordCount(domain.Chapter chapter) {
+  final metaValue = chapter.meta['wordCount'];
+  if (metaValue != null) {
+    final digitsOnly = RegExp(r'\d+');
+    final match = digitsOnly.firstMatch(metaValue);
+    if (match != null) {
+      return int.tryParse(match.group(0)!) ?? 0;
+    }
+  }
+  if (chapter.body.isNotEmpty) {
+    return RegExp(r"[\p{L}\p{N}_\-']+", unicode: true).allMatches(chapter.body).length;
+  }
+  return 0;
+}
+
+outline.ChapterStatus _mapChapterStatus(domain.ChapterStatus status) {
+  switch (status) {
+    case domain.ChapterStatus.final_:
+      return outline.ChapterStatus.done;
+    case domain.ChapterStatus.edit:
+      return outline.ChapterStatus.inProgress;
+    case domain.ChapterStatus.draft:
+      return outline.ChapterStatus.todo;
+  }
+}
+
+String _buildExcerpt(domain.Chapter chapter) {
+  final subtitle = chapter.subtitle?.trim();
+  if (subtitle != null && subtitle.isNotEmpty) {
+    return subtitle;
+  }
+  final body = chapter.body.trim();
+  if (body.isEmpty) {
+    return 'Описание появится позже.';
+  }
+  final normalized = body.replaceAll(RegExp(r'\s+'), ' ').trim();
+  if (normalized.length <= 160) {
+    return normalized;
+  }
+  return '${normalized.substring(0, 157).trim()}…';
+}

--- a/lib/views/notebook_outline_view.dart
+++ b/lib/views/notebook_outline_view.dart
@@ -9,11 +9,29 @@ import '../widgets/chapter_card.dart';
 class NotebookOutlineView extends StatefulWidget {
   final Work work;
   final List<Chapter> chapters;
+  final VoidCallback? onDictate;
+  final VoidCallback? onEdit;
+  final VoidCallback? onOpenMap;
+  final VoidCallback? onAddNode;
+  final VoidCallback? onMore;
+  final void Function(Chapter chapter)? onReadChapter;
+  final void Function(Chapter chapter)? onEditChapter;
+  final void Function(Chapter chapter)? onVoiceChapter;
+  final void Function(Chapter chapter)? onOpenChapter;
 
   const NotebookOutlineView({
     super.key,
     required this.work,
     required this.chapters,
+    this.onDictate,
+    this.onEdit,
+    this.onOpenMap,
+    this.onAddNode,
+    this.onMore,
+    this.onReadChapter,
+    this.onEditChapter,
+    this.onVoiceChapter,
+    this.onOpenChapter,
   });
 
   /// Демонстрационный экран
@@ -87,11 +105,12 @@ class _NotebookOutlineViewState extends State<NotebookOutlineView> {
                 WorkMetaHeader(
                   work: widget.work,
                   // для book
-                  onDictate: () {/* TODO: диктовка */},
-                  onEdit: () {/* TODO: редактирование */},
+                  onDictate: widget.onDictate ?? () {},
+                  onEdit: widget.onEdit ?? () {},
                   // для mindmap
-                  onOpenMap: widget.work.isMindmap ? () {/* TODO: открыть карту */} : null,
-                  onAddNode: widget.work.isMindmap ? () {/* TODO: добавить узел */} : null,
+                  onOpenMap: widget.work.isMindmap ? widget.onOpenMap : null,
+                  onAddNode: widget.work.isMindmap ? widget.onAddNode : null,
+                  onMore: widget.onMore,
                 ),
                 Padding(
                   padding: const EdgeInsets.fromLTRB(16, 8, 16, 8),
@@ -102,10 +121,10 @@ class _NotebookOutlineViewState extends State<NotebookOutlineView> {
                 const SizedBox(height: 4),
                 ...widget.chapters.map((c) => ChapterCard(
                       ch: c,
-                      onRead: () {/* TODO */},
-                      onEditOrContinue: () {/* TODO */},
-                      onVoice: () {/* TODO */},
-                      onOpen: () {/* TODO: переход к чтению/узлу */},
+                      onRead: () => widget.onReadChapter?.call(c),
+                      onEditOrContinue: () => widget.onEditChapter?.call(c),
+                      onVoice: () => widget.onVoiceChapter?.call(c),
+                      onOpen: widget.onOpenChapter != null ? () => widget.onOpenChapter!(c) : null,
                     )),
                 const SizedBox(height: 24),
               ],


### PR DESCRIPTION
## Summary
- add a BookOutlineScreen that maps store data into the new outline UI and wires outline actions to workspace and mindmap flows
- update the router so /book/:bookId renders the outline with a nested /editor route for the existing workspace
- expose callbacks on NotebookOutlineView and refresh navigation docs to reflect the outline-first flow

## Testing
- Not run (Flutter SDK unavailable in container)


------
https://chatgpt.com/codex/tasks/task_b_68dc20b5f610832292d7349056a8b7b6