### PR TITLE
Fix non-const Scaffold in book outline screen

### DIFF
--- a/lib/features/book_outline/book_outline_screen.dart
+++ b/lib/features/book_outline/book_outline_screen.dart
@@ -23,9 +23,9 @@ class BookOutlineScreen extends ConsumerWidget {
     final chapters = ref.watch(bookChaptersProvider(bookId));
 
     if (notebook == null) {
-      return const Scaffold(
+      return Scaffold(
         appBar: AppBar(),
-        body: Center(child: Text('Коллекция не найдена.')),
+        body: const Center(child: Text('Коллекция не найдена.')),
       );
     }
 


### PR DESCRIPTION
## Summary
- allow the missing notebook fallback to use a non-const Scaffold while keeping the body text const

## Testing
- not run (flutter is unavailable in the container)

------
https://chatgpt.com/codex/tasks/task_b_68dc2440ad4c8322a12625de87a72771