### PR TITLE
Fix layout overflows on notebook and onboarding screens

### DIFF
--- a/lib/views/notebook_outline_view.dart
+++ b/lib/views/notebook_outline_view.dart
@@ -84,16 +84,18 @@ class _NotebookOutlineViewState extends State<NotebookOutlineView> {
     return Scaffold(
       appBar: AppBar(
         title: Row(
-          children: [
-            const Icon(Icons.auto_stories, size: 22),
-            const SizedBox(width: 8),
-            const Text('VoxBook Studio'),
-            const Spacer(),
-            IconButton(onPressed: () {}, tooltip: 'Поиск', icon: const Icon(Icons.search)),
-            IconButton(onPressed: () {}, tooltip: 'Уведомления', icon: const Icon(Icons.notifications_none)),
-            IconButton(onPressed: () {}, tooltip: 'Настройки', icon: const Icon(Icons.settings_outlined)),
+          mainAxisSize: MainAxisSize.min,
+          children: const [
+            Icon(Icons.auto_stories, size: 22),
+            SizedBox(width: 8),
+            Text('VoxBook Studio'),
           ],
         ),
+        actions: [
+          IconButton(onPressed: () {}, tooltip: 'Поиск', icon: const Icon(Icons.search)),
+          IconButton(onPressed: () {}, tooltip: 'Уведомления', icon: const Icon(Icons.notifications_none)),
+          IconButton(onPressed: () {}, tooltip: 'Настройки', icon: const Icon(Icons.settings_outlined)),
+        ],
       ),
       body: Column(
         children: [


### PR DESCRIPTION
## Summary
- move notebook outline toolbar actions into the AppBar actions slot to avoid width overflow
- make the onboarding screen responsive by switching to a scrollable layout on compact heights

## Testing
- not run (flutter/dart tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_b_68dc285a1da88322b4a70541257a2cfb