### PR TITLE
Fix pinned header layout extent

### DIFF
--- a/lib/features/library/library_screen.dart
+++ b/lib/features/library/library_screen.dart
@@ -669,15 +669,17 @@ class _PinnedTitleHeader extends SliverPersistentHeaderDelegate {
           ]
         : null;
 
-    return DecoratedBox(
-      decoration: BoxDecoration(
-        color: Colors.white,
-        boxShadow: shadow,
-        border: const Border(
-          bottom: BorderSide(color: AppColors.border),
+    return SizedBox.expand(
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          color: Colors.white,
+          boxShadow: shadow,
+          border: const Border(
+            bottom: BorderSide(color: AppColors.border),
+          ),
         ),
+        child: child,
       ),
-      child: child,
     );
   }
 


### PR DESCRIPTION
## Summary
- ensure the pinned library header expands to its full height to satisfy sliver constraints

## Testing
- not run (flutter not available in container)


------
https://chatgpt.com/codex/tasks/task_b_68dc2fda14c08322bb6cde97d265b7dc