### PR TITLE
Add chapter reading view with adjustable preferences

### DIFF
--- a/lib/models/reading_prefs.dart
+++ b/lib/models/reading_prefs.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/material.dart';
+
+enum ReadingTheme { light, sepia, dark }
+enum ReadingFont { sans, serif, mono }
+
+class ReadingPrefs extends ChangeNotifier {
+  double fontSize;
+  ReadingTheme theme;
+  ReadingFont font;
+
+  ReadingPrefs({
+    this.fontSize = 16.0,
+    this.theme = ReadingTheme.light,
+    this.font = ReadingFont.sans,
+  });
+
+  void setSize(double value) {
+    fontSize = value.clamp(12, 28).toDouble();
+    notifyListeners();
+  }
+
+  void setTheme(ReadingTheme t) {
+    theme = t;
+    notifyListeners();
+  }
+
+  void setFont(ReadingFont f) {
+    font = f;
+    notifyListeners();
+  }
+
+  void reset() {
+    fontSize = 16.0;
+    theme = ReadingTheme.light;
+    font = ReadingFont.sans;
+    notifyListeners();
+  }
+
+  Color get bgColor {
+    switch (theme) {
+      case ReadingTheme.light:
+        return Colors.white;
+      case ReadingTheme.sepia:
+        return const Color(0xFFF8F1E3);
+      case ReadingTheme.dark:
+        return const Color(0xFF0B0F14);
+    }
+  }
+
+  Color get textColor {
+    switch (theme) {
+      case ReadingTheme.light:
+        return const Color(0xFF111827);
+      case ReadingTheme.sepia:
+        return const Color(0xFF2C2A25);
+      case ReadingTheme.dark:
+        return Colors.white;
+    }
+  }
+
+  String? get fontFamily {
+    switch (font) {
+      case ReadingFont.sans:
+        return null;
+      case ReadingFont.serif:
+        return 'Georgia';
+      case ReadingFont.mono:
+        return 'monospace';
+    }
+  }
+
+  List<String>? get fontFallback {
+    switch (font) {
+      case ReadingFont.sans:
+        return const ['Roboto', 'SF Pro Text'];
+      case ReadingFont.serif:
+        return const ['Georgia', 'Times New Roman', 'Noto Serif', 'RobotoSlab'];
+      case ReadingFont.mono:
+        return const ['Menlo', 'Consolas', 'Roboto Mono'];
+    }
+  }
+}

--- a/lib/views/chapter_read_view.dart
+++ b/lib/views/chapter_read_view.dart
@@ -1,0 +1,245 @@
+import 'package:flutter/material.dart';
+
+import '../models/chapter.dart';
+import '../models/reading_prefs.dart';
+import '../shared/tokens/design_tokens.dart';
+import '../widgets/billing_bar.dart';
+import '../widgets/reading_progress_bar.dart';
+import '../widgets/reading_settings_panel.dart';
+
+class ChapterReadView extends StatefulWidget {
+  final String workId;
+  final Chapter chapter;
+  final String body;
+
+  const ChapterReadView({
+    super.key,
+    required this.workId,
+    required this.chapter,
+    required this.body,
+  });
+
+  factory ChapterReadView.demo() {
+    const body = '''
+Джон проснулся, как всегда, в шесть утра. Солнечные лучи пробивались сквозь тонкие занавески его маленькой квартиры на окраине города. Он потянулся, зевнул и неохотно поднялся с кровати.
+
+Каждое утро было одинаковым: душ, завтрак из овсянки и кофе, поездка на работу в переполненном автобусе. Джон работал бухгалтером в небольшой фирме уже пять лет, и каждый день казался копией предыдущего.
+
+Но сегодня что-то было не так. Когда он открыл почтовый ящик, там лежало письмо без обратного адреса. Конверт был сделан из плотной бумаги кремового цвета, а его имя было написано элегантным почерком.
+
+"Дорогой Джон", — начиналось письмо, — "Ваша жизнь вот-вот изменится навсегда..."
+''';
+    const ch = Chapter(
+      id: 'c1',
+      title: 'Глава 1: Обычный мир',
+      words: 3245,
+      status: ChapterStatus.inProgress,
+      excerpt: '',
+    );
+    return const ChapterReadView(workId: 'w1', chapter: ch, body: body);
+  }
+
+  @override
+  State<ChapterReadView> createState() => _ChapterReadViewState();
+}
+
+class _ChapterReadViewState extends State<ChapterReadView> {
+  late final ReadingPrefs prefs;
+  final ScrollController scrollController = ScrollController();
+  double progress = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    prefs = ReadingPrefs();
+    scrollController.addListener(_onScroll);
+    prefs.addListener(_onPrefsChanged);
+  }
+
+  @override
+  void dispose() {
+    scrollController.removeListener(_onScroll);
+    scrollController.dispose();
+    prefs.removeListener(_onPrefsChanged);
+    prefs.dispose();
+    super.dispose();
+  }
+
+  void _onPrefsChanged() => setState(() {});
+
+  void _onScroll() {
+    if (!scrollController.hasClients) return;
+    final position = scrollController.position;
+    final max = position.maxScrollExtent;
+    final offset = position.pixels;
+    final ratio = max <= 0 ? 0.0 : (offset / max).clamp(0.0, 1.0);
+    if (ratio != progress) {
+      setState(() => progress = ratio);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back),
+          tooltip: 'Назад',
+          onPressed: () {
+            Navigator.of(context).maybePop();
+          },
+        ),
+        title: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: const [
+            Icon(Icons.auto_stories, size: 22),
+            SizedBox(width: 8),
+            Text('VoxBook Studio'),
+          ],
+        ),
+        actions: [
+          IconButton(onPressed: () {}, tooltip: 'Поиск', icon: const Icon(Icons.search)),
+          IconButton(onPressed: () {}, tooltip: 'Уведомления', icon: const Icon(Icons.notifications_none)),
+          IconButton(onPressed: () {}, tooltip: 'Настройки', icon: const Icon(Icons.settings_outlined)),
+        ],
+      ),
+      bottomNavigationBar: Container(
+        decoration: BoxDecoration(
+          color: Theme.of(context).colorScheme.surface,
+          border: Border(top: BorderSide(color: Theme.of(context).dividerColor.withOpacity(.4))),
+        ),
+        padding: const EdgeInsets.fromLTRB(16, 10, 16, 10),
+        child: SafeArea(
+          top: false,
+          child: Row(
+            children: [
+              Expanded(
+                child: OutlinedButton.icon(
+                  onPressed: () {},
+                  icon: const Icon(Icons.edit_outlined),
+                  label: const Text('Редактировать'),
+                  style: OutlinedButton.styleFrom(
+                    padding: const EdgeInsets.symmetric(vertical: 12),
+                    shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+                  ),
+                ),
+              ),
+              const SizedBox(width: 10),
+              Expanded(
+                child: ElevatedButton.icon(
+                  onPressed: () {},
+                  icon: const Icon(Icons.graphic_eq_rounded),
+                  label: const Text('Озвучить'),
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: AppColors.primary,
+                    foregroundColor: Colors.white,
+                    padding: const EdgeInsets.symmetric(vertical: 12),
+                    shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+      body: Column(
+        children: [
+          const BillingBar(credits: 2450, micTime: Duration(minutes: 45), requests: 120),
+          _ChapterHeader(title: widget.chapter.title, words: widget.chapter.words),
+          ReadingProgressBar(progress: progress, words: widget.chapter.words),
+          Expanded(
+            child: Container(
+              color: prefs.bgColor,
+              child: Scrollbar(
+                controller: scrollController,
+                child: SingleChildScrollView(
+                  controller: scrollController,
+                  padding: const EdgeInsets.fromLTRB(16, 4, 16, 120),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      _ReadingBody(text: widget.body, prefs: prefs),
+                      const SizedBox(height: 20),
+                      ReadingSettingsPanel(prefs: prefs),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ChapterHeader extends StatelessWidget {
+  final String title;
+  final int words;
+
+  const _ChapterHeader({required this.title, required this.words});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final captionColor = theme.colorScheme.onSurface.withOpacity(.55);
+    return Container(
+      padding: const EdgeInsets.fromLTRB(16, 10, 8, 6),
+      child: Row(
+        children: [
+          Expanded(
+            child: Column(
+              children: [
+                Text(
+                  title,
+                  textAlign: TextAlign.center,
+                  style: theme.textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w800),
+                ),
+                const SizedBox(height: 4),
+                Text('${_fmt(words)} слов', style: theme.textTheme.bodySmall?.copyWith(color: captionColor)),
+              ],
+            ),
+          ),
+          PopupMenuButton<String>(
+            tooltip: 'Ещё',
+            itemBuilder: (_) => const [
+              PopupMenuItem(value: 'bookmark', child: Text('Добавить закладку')),
+              PopupMenuItem(value: 'share', child: Text('Поделиться')),
+              PopupMenuItem(value: 'export', child: Text('Экспорт')),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  static String _fmt(int n) {
+    final s = n.toString();
+    final buf = StringBuffer();
+    for (var i = 0; i < s.length; i++) {
+      final p = s.length - i;
+      buf.write(s[i]);
+      if (p > 1 && p % 3 == 1) buf.write(' ');
+    }
+    return buf.toString();
+  }
+}
+
+class _ReadingBody extends StatelessWidget {
+  final String text;
+  final ReadingPrefs prefs;
+
+  const _ReadingBody({required this.text, required this.prefs});
+
+  @override
+  Widget build(BuildContext context) {
+    final style = TextStyle(
+      fontSize: prefs.fontSize,
+      height: 1.6,
+      color: prefs.textColor,
+      fontFamily: prefs.fontFamily,
+      fontFamilyFallback: prefs.fontFallback,
+    );
+    return Text(text.trim(), style: style);
+  }
+}

--- a/lib/widgets/reading_progress_bar.dart
+++ b/lib/widgets/reading_progress_bar.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/material.dart';
+
+import '../shared/tokens/design_tokens.dart';
+
+class ReadingProgressBar extends StatelessWidget {
+  final double progress;
+  final int words;
+
+  const ReadingProgressBar({
+    super.key,
+    required this.progress,
+    required this.words,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final pct = (progress * 100).clamp(0, 100).round();
+    final theme = Theme.of(context);
+    final textTheme = theme.textTheme;
+    final onSurface = theme.colorScheme.onSurface.withOpacity(.55);
+    final trackColor = theme.colorScheme.onSurface.withOpacity(.08);
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 8, 16, 12),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Text(
+                'Прогресс чтения',
+                style: textTheme.titleSmall?.copyWith(fontWeight: FontWeight.w700) ??
+                    const TextStyle(fontWeight: FontWeight.w700),
+              ),
+              const Spacer(),
+              Text('$pct%'),
+            ],
+          ),
+          const SizedBox(height: 8),
+          ClipRRect(
+            borderRadius: BorderRadius.circular(999),
+            child: LinearProgressIndicator(
+              value: progress.clamp(0, 1).toDouble(),
+              minHeight: 8,
+              backgroundColor: trackColor,
+              valueColor: const AlwaysStoppedAnimation<Color>(AppColors.primary),
+            ),
+          ),
+          const SizedBox(height: 6),
+          Text(
+            '${_fmt(words)} слов',
+            style: textTheme.bodySmall?.copyWith(color: onSurface) ?? TextStyle(color: onSurface),
+          ),
+        ],
+      ),
+    );
+  }
+
+  static String _fmt(int n) {
+    final s = n.toString();
+    final buf = StringBuffer();
+    for (var i = 0; i < s.length; i++) {
+      final p = s.length - i;
+      buf.write(s[i]);
+      if (p > 1 && p % 3 == 1) buf.write(' ');
+    }
+    return buf.toString();
+  }
+}

--- a/lib/widgets/reading_settings_panel.dart
+++ b/lib/widgets/reading_settings_panel.dart
@@ -1,0 +1,156 @@
+import 'package:flutter/material.dart';
+
+import '../models/reading_prefs.dart';
+import '../shared/tokens/design_tokens.dart';
+
+class ReadingSettingsPanel extends StatelessWidget {
+  final ReadingPrefs prefs;
+
+  const ReadingSettingsPanel({super.key, required this.prefs});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 8, 16, 16),
+      child: Card(
+        elevation: 0.5,
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(16, 14, 16, 10),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  Text(
+                    'Настройки чтения',
+                    style: theme.textTheme.titleSmall?.copyWith(fontWeight: FontWeight.w700) ??
+                        const TextStyle(fontWeight: FontWeight.w700),
+                  ),
+                  const Spacer(),
+                  TextButton(
+                    onPressed: prefs.reset,
+                    child: const Text('Сбросить'),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 10),
+              _sizeControl(context),
+              const SizedBox(height: 12),
+              _themeControl(context),
+              const SizedBox(height: 12),
+              _fontControl(context),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _sizeControl(BuildContext context) {
+    final textStyle = Theme.of(context).textTheme.bodyMedium;
+    return Row(
+      children: [
+        _chipLabel(icon: Icons.text_fields, label: 'Размер'),
+        Expanded(
+          child: Slider(
+            min: 12,
+            max: 28,
+            divisions: 16,
+            value: prefs.fontSize,
+            label: prefs.fontSize.round().toString(),
+            onChanged: prefs.setSize,
+          ),
+        ),
+        Text(prefs.fontSize.round().toString(), style: textStyle),
+      ],
+    );
+  }
+
+  Widget _themeControl(BuildContext context) {
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        _chipLabel(icon: Icons.palette_outlined, label: 'Тема'),
+        const SizedBox(width: 8),
+        Expanded(
+          child: Wrap(
+            spacing: 6,
+            runSpacing: 6,
+            children: [
+              _segBtn(context, 'Светлая', prefs.theme == ReadingTheme.light,
+                  () => prefs.setTheme(ReadingTheme.light)),
+              _segBtn(context, 'Сепия', prefs.theme == ReadingTheme.sepia,
+                  () => prefs.setTheme(ReadingTheme.sepia)),
+              _segBtn(context, 'Тёмная', prefs.theme == ReadingTheme.dark,
+                  () => prefs.setTheme(ReadingTheme.dark)),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _fontControl(BuildContext context) {
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        _chipLabel(icon: Icons.font_download_outlined, label: 'Шрифт'),
+        const SizedBox(width: 8),
+        Expanded(
+          child: Wrap(
+            spacing: 6,
+            runSpacing: 6,
+            children: [
+              _segBtn(context, 'Sans', prefs.font == ReadingFont.sans,
+                  () => prefs.setFont(ReadingFont.sans)),
+              _segBtn(context, 'Serif', prefs.font == ReadingFont.serif,
+                  () => prefs.setFont(ReadingFont.serif)),
+              _segBtn(context, 'Mono', prefs.font == ReadingFont.mono,
+                  () => prefs.setFont(ReadingFont.mono)),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  static Widget _chipLabel({required IconData icon, required String label}) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+      decoration: BoxDecoration(
+        color: AppColors.primary.withOpacity(.12),
+        borderRadius: BorderRadius.circular(999),
+      ),
+      child: Row(
+        children: [
+          Icon(icon, size: 16, color: AppColors.primary),
+          const SizedBox(width: 6),
+          Text(label,
+              style: const TextStyle(fontWeight: FontWeight.w700, color: AppColors.primary)),
+        ],
+      ),
+    );
+  }
+
+  static Widget _segBtn(BuildContext context, String label, bool active, VoidCallback onTap) {
+    final theme = Theme.of(context);
+    final borderColor = active
+        ? AppColors.primary.withOpacity(.3)
+        : theme.colorScheme.onSurface.withOpacity(.12);
+    final textColor = active ? AppColors.primary : theme.colorScheme.onSurface;
+    return InkWell(
+      borderRadius: BorderRadius.circular(10),
+      onTap: onTap,
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
+        decoration: BoxDecoration(
+          color: active ? AppColors.primary.withOpacity(.12) : Colors.transparent,
+          border: Border.all(color: borderColor),
+          borderRadius: BorderRadius.circular(10),
+        ),
+        child: Text(label, style: theme.textTheme.bodyMedium?.copyWith(color: textColor)),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add a reading preferences change notifier for theme, font size, and font family
- create reusable widgets for the chapter progress indicator and reading settings controls
- implement the chapter reading view with sticky billing header, scrollable body, and persistent action bar

## Testing
- not run (not available in container)

------
https://chatgpt.com/codex/tasks/task_b_68dc390867788322adf773e4eb223dac