### PR TITLE
Add dedicated chapter read screen

### DIFF
--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -6,6 +6,7 @@ import 'package:voicebook/core/providers/app_providers.dart';
 import 'package:voicebook/features/ai_composer/ai_composer_drawer.dart';
 import 'package:voicebook/features/book_outline/book_outline_screen.dart';
 import 'package:voicebook/features/book_workspace/book_workspace_screen.dart';
+import 'package:voicebook/features/chapter_read/chapter_read_screen.dart';
 import 'package:voicebook/features/export/export_screen.dart';
 import 'package:voicebook/features/library/library_screen.dart';
 import 'package:voicebook/features/onboarding/onboarding_screen.dart';
@@ -68,6 +69,23 @@ final appRouterProvider = Provider<GoRouter>((ref) {
           );
         },
         routes: [
+          GoRoute(
+            path: 'chapter/:chapterId/read',
+            name: 'chapterRead',
+            pageBuilder: (context, state) {
+              final bookId = state.pathParameters['bookId']!;
+              final chapterId = state.pathParameters['chapterId']!;
+              return CustomTransitionPage(
+                key: state.pageKey,
+                child: ChapterReadScreen(bookId: bookId, chapterId: chapterId),
+                transitionsBuilder: (context, animation, secondaryAnimation, child) {
+                  final tween = Tween<Offset>(begin: const Offset(1, 0), end: Offset.zero)
+                      .chain(CurveTween(curve: Curves.easeOutCubic));
+                  return SlideTransition(position: animation.drive(tween), child: child);
+                },
+              );
+            },
+          ),
           GoRoute(
             path: 'editor',
             name: 'bookEditor',

--- a/lib/features/book_outline/workspace_navigation.dart
+++ b/lib/features/book_outline/workspace_navigation.dart
@@ -1,0 +1,44 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:voicebook/core/providers/app_providers.dart';
+import 'package:voicebook/core/storage/ui_state_storage.dart';
+
+enum WorkspaceIntent { list, reading, edit }
+
+void prepareWorkspace(
+  WidgetRef ref, {
+  required String bookId,
+  String? chapterId,
+  WorkspaceIntent intent = WorkspaceIntent.list,
+}) {
+  if (chapterId != null) {
+    ref.read(currentChapterIdProvider(bookId).notifier).state = chapterId;
+  }
+
+  unawaited(
+    persistWorkspaceIntent(bookId: bookId, chapterId: chapterId, intent: intent),
+  );
+}
+
+Future<void> persistWorkspaceIntent({
+  required String bookId,
+  String? chapterId,
+  WorkspaceIntent intent = WorkspaceIntent.list,
+}) async {
+  final storage = await UiStateStorage.open();
+  final raw = encodeWorkspaceIntent(intent, chapterId: chapterId);
+  await storage.writeWorkspaceMode(bookId, raw);
+}
+
+String encodeWorkspaceIntent(WorkspaceIntent intent, {String? chapterId}) {
+  switch (intent) {
+    case WorkspaceIntent.list:
+      return 'list';
+    case WorkspaceIntent.reading:
+      return chapterId != null ? 'reading::$chapterId' : 'list';
+    case WorkspaceIntent.edit:
+      return chapterId != null ? 'edit::$chapterId' : 'list';
+  }
+}

--- a/lib/features/chapter_read/chapter_read_screen.dart
+++ b/lib/features/chapter_read/chapter_read_screen.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import 'package:voicebook/core/providers/app_providers.dart';
+import 'package:voicebook/features/book_outline/workspace_navigation.dart';
+import 'package:voicebook/shared/mappers/chapter_view_mapper.dart';
+import 'package:voicebook/views/chapter_read_view.dart';
+
+class ChapterReadScreen extends ConsumerStatefulWidget {
+  const ChapterReadScreen({super.key, required this.bookId, required this.chapterId});
+
+  final String bookId;
+  final String chapterId;
+
+  @override
+  ConsumerState<ChapterReadScreen> createState() => _ChapterReadScreenState();
+}
+
+class _ChapterReadScreenState extends ConsumerState<ChapterReadScreen> {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) {
+        return;
+      }
+      prepareWorkspace(
+        ref,
+        bookId: widget.bookId,
+        chapterId: widget.chapterId,
+        intent: WorkspaceIntent.reading,
+      );
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final chapter = ref.watch(chapterProvider((bookId: widget.bookId, chapterId: widget.chapterId)));
+
+    if (chapter == null) {
+      return Scaffold(
+        appBar: AppBar(),
+        body: const Center(child: Text('Глава не найдена. Вернитесь к оглавлению.')),
+      );
+    }
+
+    final viewChapter = mapDomainChapterToView(chapter);
+    final bodyText = chapter.body.trim().isEmpty
+        ? 'Эта глава пока пустая. Перейдите в редактор, чтобы добавить текст.'
+        : chapter.body;
+
+    void openEditor({WorkspaceIntent intent = WorkspaceIntent.edit}) {
+      prepareWorkspace(
+        ref,
+        bookId: widget.bookId,
+        chapterId: widget.chapterId,
+        intent: intent,
+      );
+      context.pushNamed('bookEditor', pathParameters: {'bookId': widget.bookId});
+    }
+
+    return ChapterReadView(
+      workId: widget.bookId,
+      chapter: viewChapter,
+      body: bodyText,
+      onEdit: () => openEditor(intent: WorkspaceIntent.edit),
+      onVoice: () => openEditor(intent: WorkspaceIntent.edit),
+    );
+  }
+}

--- a/lib/shared/mappers/chapter_view_mapper.dart
+++ b/lib/shared/mappers/chapter_view_mapper.dart
@@ -1,0 +1,54 @@
+import 'package:voicebook/core/models/chapter.dart' as domain;
+import 'package:voicebook/models/chapter.dart' as view;
+
+view.Chapter mapDomainChapterToView(domain.Chapter chapter) {
+  return view.Chapter(
+    id: chapter.id,
+    title: chapter.title,
+    words: _resolveWordCount(chapter),
+    status: _mapChapterStatus(chapter.status),
+    excerpt: _buildExcerpt(chapter),
+  );
+}
+
+int _resolveWordCount(domain.Chapter chapter) {
+  final metaValue = chapter.meta['wordCount'];
+  if (metaValue != null) {
+    final digitsOnly = RegExp(r'\d+');
+    final match = digitsOnly.firstMatch(metaValue);
+    if (match != null) {
+      return int.tryParse(match.group(0)!) ?? 0;
+    }
+  }
+  if (chapter.body.isNotEmpty) {
+    return RegExp(r"[\p{L}\p{N}_\-']+", unicode: true).allMatches(chapter.body).length;
+  }
+  return 0;
+}
+
+view.ChapterStatus _mapChapterStatus(domain.ChapterStatus status) {
+  switch (status) {
+    case domain.ChapterStatus.final_:
+      return view.ChapterStatus.done;
+    case domain.ChapterStatus.edit:
+      return view.ChapterStatus.inProgress;
+    case domain.ChapterStatus.draft:
+      return view.ChapterStatus.todo;
+  }
+}
+
+String _buildExcerpt(domain.Chapter chapter) {
+  final subtitle = chapter.subtitle?.trim();
+  if (subtitle != null && subtitle.isNotEmpty) {
+    return subtitle;
+  }
+  final body = chapter.body.trim();
+  if (body.isEmpty) {
+    return 'Описание появится позже.';
+  }
+  final normalized = body.replaceAll(RegExp(r'\s+'), ' ').trim();
+  if (normalized.length <= 160) {
+    return normalized;
+  }
+  return '${normalized.substring(0, 157).trim()}…';
+}

--- a/lib/views/chapter_read_view.dart
+++ b/lib/views/chapter_read_view.dart
@@ -11,12 +11,16 @@ class ChapterReadView extends StatefulWidget {
   final String workId;
   final Chapter chapter;
   final String body;
+  final VoidCallback? onEdit;
+  final VoidCallback? onVoice;
 
   const ChapterReadView({
     super.key,
     required this.workId,
     required this.chapter,
     required this.body,
+    this.onEdit,
+    this.onVoice,
   });
 
   factory ChapterReadView.demo() {
@@ -115,7 +119,7 @@ class _ChapterReadViewState extends State<ChapterReadView> {
             children: [
               Expanded(
                 child: OutlinedButton.icon(
-                  onPressed: () {},
+                  onPressed: widget.onEdit,
                   icon: const Icon(Icons.edit_outlined),
                   label: const Text('Редактировать'),
                   style: OutlinedButton.styleFrom(
@@ -127,7 +131,7 @@ class _ChapterReadViewState extends State<ChapterReadView> {
               const SizedBox(width: 10),
               Expanded(
                 child: ElevatedButton.icon(
-                  onPressed: () {},
+                  onPressed: widget.onVoice,
                   icon: const Icon(Icons.graphic_eq_rounded),
                   label: const Text('Озвучить'),
                   style: ElevatedButton.styleFrom(


### PR DESCRIPTION
## Summary
- add a dedicated `ChapterReadScreen` route and hook it into the book router
- update the outline screen to launch the new chapter reader and share workspace intent helpers
- expose callbacks from `ChapterReadView` and add a mapper for chapter view models

## Testing
- not run (flutter command unavailable in container)


------
https://chatgpt.com/codex/tasks/task_b_68dc3c34620c83228ce5d0b498f8bc3d