### PR TITLE
Add chapter edit view with compact text settings

### DIFF
--- a/lib/views/chapter_edit_view.dart
+++ b/lib/views/chapter_edit_view.dart
@@ -1,0 +1,233 @@
+import 'package:flutter/material.dart';
+
+import '../models/chapter.dart';
+import '../models/reading_prefs.dart';
+import '../shared/tokens/design_tokens.dart';
+import '../widgets/billing_bar.dart';
+import '../widgets/compact_text_settings_bar.dart';
+
+class ChapterEditView extends StatefulWidget {
+  final String workId;
+  final Chapter chapter;
+  final String initialText;
+  final VoidCallback? onVoice;
+  final VoidCallback? onEditMode;
+
+  const ChapterEditView({
+    super.key,
+    required this.workId,
+    required this.chapter,
+    required this.initialText,
+    this.onVoice,
+    this.onEditMode,
+  });
+
+  factory ChapterEditView.demo() {
+    const chapter = Chapter(
+      id: 'c1',
+      title: 'Пролог: Ночная станция',
+      words: 131,
+      status: ChapterStatus.inProgress,
+      excerpt: '',
+    );
+    const body =
+        'Также отмечаем эмоции собеседников и их реакцию на туман станции. '
+        'Вчера вечером мы собрали черновики сессии и нашли сильные цитаты из интервью...';
+    return const ChapterEditView(
+      workId: 'w1',
+      chapter: chapter,
+      initialText: body,
+    );
+  }
+
+  @override
+  State<ChapterEditView> createState() => _ChapterEditViewState();
+}
+
+class _ChapterEditViewState extends State<ChapterEditView> {
+  late final ReadingPrefs prefs;
+  late final TextEditingController editorController;
+
+  @override
+  void initState() {
+    super.initState();
+    prefs = ReadingPrefs();
+    prefs.addListener(_onPrefsChanged);
+    editorController = TextEditingController(text: widget.initialText);
+  }
+
+  @override
+  void dispose() {
+    prefs.removeListener(_onPrefsChanged);
+    prefs.dispose();
+    editorController.dispose();
+    super.dispose();
+  }
+
+  void _onPrefsChanged() => setState(() {});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final editorStyle = TextStyle(
+      fontSize: prefs.fontSize,
+      height: 1.6,
+      color: prefs.textColor,
+      fontFamily: prefs.fontFamily,
+      fontFamilyFallback: prefs.fontFallback,
+    );
+
+    return Scaffold(
+      appBar: AppBar(
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back),
+          tooltip: 'Назад',
+          onPressed: () => Navigator.of(context).maybePop(),
+        ),
+        title: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: const [
+            Icon(Icons.auto_stories, size: 22),
+            SizedBox(width: 8),
+            Text('VoxBook Studio'),
+          ],
+        ),
+        actions: [
+          IconButton(onPressed: () {}, tooltip: 'Поиск', icon: const Icon(Icons.search)),
+          IconButton(onPressed: () {}, tooltip: 'Уведомления', icon: const Icon(Icons.notifications_none)),
+          IconButton(onPressed: () {}, tooltip: 'Настройки', icon: const Icon(Icons.settings_outlined)),
+        ],
+      ),
+      bottomNavigationBar: SafeArea(
+        top: false,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            CompactTextSettingsBar(prefs: prefs),
+            Container(
+              decoration: BoxDecoration(
+                color: theme.cardColor,
+                border: Border(top: BorderSide(color: theme.dividerColor.withOpacity(.4))),
+              ),
+              padding: const EdgeInsets.fromLTRB(16, 8, 16, 10),
+              child: Row(
+                children: [
+                  Expanded(
+                    child: OutlinedButton.icon(
+                      onPressed: widget.onEditMode ?? () {},
+                      icon: const Icon(Icons.edit_outlined),
+                      label: const Text('Редактировать'),
+                      style: OutlinedButton.styleFrom(
+                        padding: const EdgeInsets.symmetric(vertical: 12),
+                        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+                      ),
+                    ),
+                  ),
+                  const SizedBox(width: 10),
+                  Expanded(
+                    child: ElevatedButton.icon(
+                      onPressed: widget.onVoice ?? () {},
+                      icon: const Icon(Icons.graphic_eq_rounded),
+                      label: const Text('Озвучить'),
+                      style: ElevatedButton.styleFrom(
+                        backgroundColor: AppColors.primary,
+                        foregroundColor: Colors.white,
+                        padding: const EdgeInsets.symmetric(vertical: 12),
+                        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+      body: Column(
+        children: [
+          const BillingBar(credits: 2450, micTime: Duration(minutes: 45), requests: 120),
+          _ChapterHeader(title: widget.chapter.title, words: widget.chapter.words),
+          Expanded(
+            child: Container(
+              color: prefs.bgColor,
+              child: Scrollbar(
+                child: SingleChildScrollView(
+                  padding: const EdgeInsets.fromLTRB(16, 8, 16, 160),
+                  child: TextField(
+                    controller: editorController,
+                    maxLines: null,
+                    minLines: 12,
+                    keyboardType: TextInputType.multiline,
+                    scrollPadding: const EdgeInsets.only(bottom: 200),
+                    decoration: const InputDecoration(
+                      border: InputBorder.none,
+                      isCollapsed: true,
+                    ),
+                    style: editorStyle,
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ChapterHeader extends StatelessWidget {
+  final String title;
+  final int words;
+
+  const _ChapterHeader({required this.title, required this.words});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final captionColor = theme.colorScheme.onSurface.withOpacity(.55);
+    return Container(
+      padding: const EdgeInsets.fromLTRB(16, 10, 8, 6),
+      child: Row(
+        children: [
+          Expanded(
+            child: Column(
+              children: [
+                Text(
+                  title,
+                  textAlign: TextAlign.center,
+                  style: theme.textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w800),
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  '${_fmt(words)} слов',
+                  style: theme.textTheme.bodySmall?.copyWith(color: captionColor),
+                ),
+              ],
+            ),
+          ),
+          PopupMenuButton<String>(
+            tooltip: 'Ещё',
+            itemBuilder: (_) => const [
+              PopupMenuItem(value: 'ai', child: Text('Сформировать текст')),
+              PopupMenuItem(value: 'dictate', child: Text('Диктовать')),
+              PopupMenuItem(value: 'export', child: Text('Экспорт')),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  static String _fmt(int value) {
+    final raw = value.toString();
+    final buffer = StringBuffer();
+    for (var i = 0; i < raw.length; i++) {
+      final remaining = raw.length - i;
+      buffer.write(raw[i]);
+      if (remaining > 1 && remaining % 3 == 1) {
+        buffer.write(' ');
+      }
+    }
+    return buffer.toString();
+  }
+}

--- a/lib/widgets/compact_text_settings_bar.dart
+++ b/lib/widgets/compact_text_settings_bar.dart
@@ -1,0 +1,200 @@
+import 'package:flutter/material.dart';
+
+import '../models/reading_prefs.dart';
+import '../shared/tokens/design_tokens.dart';
+
+class CompactTextSettingsBar extends StatelessWidget {
+  final ReadingPrefs prefs;
+  final EdgeInsets padding;
+
+  const CompactTextSettingsBar({
+    super.key,
+    required this.prefs,
+    this.padding = const EdgeInsets.fromLTRB(12, 8, 12, 8),
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Material(
+      color: theme.cardColor,
+      elevation: 2,
+      borderRadius: const BorderRadius.only(
+        topLeft: Radius.circular(12),
+        topRight: Radius.circular(12),
+      ),
+      child: Padding(
+        padding: padding,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Row(
+              children: [
+                _chip('Размер', Icons.text_fields),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: SliderTheme(
+                    data: SliderTheme.of(context).copyWith(
+                      trackHeight: 2.5,
+                      thumbShape: const RoundSliderThumbShape(
+                        enabledThumbRadius: 8,
+                      ),
+                    ),
+                    child: Slider(
+                      min: 12,
+                      max: 28,
+                      divisions: 16,
+                      value: prefs.fontSize,
+                      onChanged: prefs.setSize,
+                    ),
+                  ),
+                ),
+                SizedBox(
+                  width: 32,
+                  child: Text(
+                    prefs.fontSize.round().toString(),
+                    textAlign: TextAlign.right,
+                    style: theme.textTheme.labelMedium,
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 6),
+            _hScrollRow(
+              label: _chip('Тема', Icons.palette_outlined),
+              children: [
+                _segBtn(
+                  context,
+                  'Светлая',
+                  prefs.theme == ReadingTheme.light,
+                  () => prefs.setTheme(ReadingTheme.light),
+                ),
+                _segBtn(
+                  context,
+                  'Сепия',
+                  prefs.theme == ReadingTheme.sepia,
+                  () => prefs.setTheme(ReadingTheme.sepia),
+                ),
+                _segBtn(
+                  context,
+                  'Тёмная',
+                  prefs.theme == ReadingTheme.dark,
+                  () => prefs.setTheme(ReadingTheme.dark),
+                ),
+              ],
+            ),
+            const SizedBox(height: 6),
+            _hScrollRow(
+              label: _chip('Шрифт', Icons.font_download_outlined),
+              children: [
+                _segBtn(
+                  context,
+                  'Sans',
+                  prefs.font == ReadingFont.sans,
+                  () => prefs.setFont(ReadingFont.sans),
+                ),
+                _segBtn(
+                  context,
+                  'Serif',
+                  prefs.font == ReadingFont.serif,
+                  () => prefs.setFont(ReadingFont.serif),
+                ),
+                _segBtn(
+                  context,
+                  'Mono',
+                  prefs.font == ReadingFont.mono,
+                  () => prefs.setFont(ReadingFont.mono),
+                ),
+                TextButton(
+                  onPressed: prefs.reset,
+                  child: const Text('Сбросить'),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  static Widget _chip(String text, IconData icon) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      decoration: BoxDecoration(
+        color: AppColors.primary.withOpacity(.12),
+        borderRadius: BorderRadius.circular(999),
+      ),
+      child: Row(
+        children: [
+          Icon(icon, size: 14, color: AppColors.primary),
+          const SizedBox(width: 6),
+          Text(
+            text,
+            style: const TextStyle(
+              color: AppColors.primary,
+              fontWeight: FontWeight.w700,
+              fontSize: 12,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  static Widget _segBtn(
+    BuildContext context,
+    String label,
+    bool active,
+    VoidCallback onTap,
+  ) {
+    final theme = Theme.of(context);
+    final textColor = active
+        ? AppColors.primary
+        : theme.textTheme.bodyMedium?.color ?? theme.colorScheme.onSurface;
+    return Padding(
+      padding: const EdgeInsets.only(right: 6),
+      child: InkWell(
+        borderRadius: BorderRadius.circular(9),
+        onTap: onTap,
+        child: Container(
+          padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+          decoration: BoxDecoration(
+            color: active ? AppColors.primary.withOpacity(.12) : Colors.transparent,
+            border: Border.all(
+              color: active
+                  ? AppColors.primary.withOpacity(.3)
+                  : theme.colorScheme.onSurface.withOpacity(.1),
+            ),
+            borderRadius: BorderRadius.circular(9),
+          ),
+          child: Text(
+            label,
+            style: TextStyle(
+              fontSize: 12,
+              fontWeight: FontWeight.w600,
+              color: textColor,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  static Widget _hScrollRow({
+    required Widget label,
+    required List<Widget> children,
+  }) {
+    return Row(
+      children: [
+        label,
+        const SizedBox(width: 8),
+        Expanded(
+          child: SingleChildScrollView(
+            scrollDirection: Axis.horizontal,
+            child: Row(children: children),
+          ),
+        ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add the chapter edit view scaffold with billing banner, chapter header, and sticky action bar
- implement the compact text settings bar with size slider and theme/font toggles linked to reading preferences
- wire the editor to react to preference changes and ensure safe scrolling with the persistent bottom controls

## Testing
- not run (Flutter/Dart SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_b_68dc4434e76c832295cff2a31423ab6b