### PR TITLE
Revamp chapter edit text settings bar

### DIFF
--- a/lib/views/chapter_edit_view.dart
+++ b/lib/views/chapter_edit_view.dart
@@ -98,49 +98,53 @@ class _ChapterEditViewState extends State<ChapterEditView> {
           IconButton(onPressed: () {}, tooltip: 'Настройки', icon: const Icon(Icons.settings_outlined)),
         ],
       ),
-      bottomNavigationBar: SafeArea(
-        top: false,
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            CompactTextSettingsBar(prefs: prefs),
-            Container(
-              decoration: BoxDecoration(
-                color: theme.cardColor,
-                border: Border(top: BorderSide(color: theme.dividerColor.withOpacity(.4))),
-              ),
-              padding: const EdgeInsets.fromLTRB(16, 8, 16, 10),
-              child: Row(
-                children: [
-                  Expanded(
-                    child: OutlinedButton.icon(
-                      onPressed: widget.onEditMode ?? () {},
-                      icon: const Icon(Icons.edit_outlined),
-                      label: const Text('Редактировать'),
-                      style: OutlinedButton.styleFrom(
-                        padding: const EdgeInsets.symmetric(vertical: 12),
-                        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+      bottomNavigationBar: DecoratedBox(
+        decoration: BoxDecoration(
+          color: theme.colorScheme.surface,
+          border: Border(top: BorderSide(color: theme.dividerColor.withOpacity(.25))),
+        ),
+        child: SafeArea(
+          top: false,
+          minimum: const EdgeInsets.only(bottom: 12),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              CompactTextSettingsBar(prefs: prefs),
+              const SizedBox(height: 12),
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 16),
+                child: Row(
+                  children: [
+                    Expanded(
+                      child: OutlinedButton.icon(
+                        onPressed: widget.onEditMode ?? () {},
+                        icon: const Icon(Icons.edit_outlined),
+                        label: const Text('Редактировать'),
+                        style: OutlinedButton.styleFrom(
+                          padding: const EdgeInsets.symmetric(vertical: 12),
+                          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+                        ),
                       ),
                     ),
-                  ),
-                  const SizedBox(width: 10),
-                  Expanded(
-                    child: ElevatedButton.icon(
-                      onPressed: widget.onVoice ?? () {},
-                      icon: const Icon(Icons.graphic_eq_rounded),
-                      label: const Text('Озвучить'),
-                      style: ElevatedButton.styleFrom(
-                        backgroundColor: AppColors.primary,
-                        foregroundColor: Colors.white,
-                        padding: const EdgeInsets.symmetric(vertical: 12),
-                        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+                    const SizedBox(width: 10),
+                    Expanded(
+                      child: ElevatedButton.icon(
+                        onPressed: widget.onVoice ?? () {},
+                        icon: const Icon(Icons.graphic_eq_rounded),
+                        label: const Text('Озвучить'),
+                        style: ElevatedButton.styleFrom(
+                          backgroundColor: AppColors.primary,
+                          foregroundColor: Colors.white,
+                          padding: const EdgeInsets.symmetric(vertical: 12),
+                          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+                        ),
                       ),
                     ),
-                  ),
-                ],
+                  ],
+                ),
               ),
-            ),
-          ],
+            ],
+          ),
         ),
       ),
       body: Column(

--- a/lib/widgets/compact_text_settings_bar.dart
+++ b/lib/widgets/compact_text_settings_bar.dart
@@ -1,3 +1,5 @@
+import 'dart:ui';
+
 import 'package:flutter/material.dart';
 
 import '../models/reading_prefs.dart';
@@ -10,133 +12,188 @@ class CompactTextSettingsBar extends StatelessWidget {
   const CompactTextSettingsBar({
     super.key,
     required this.prefs,
-    this.padding = const EdgeInsets.fromLTRB(12, 8, 12, 8),
+    this.padding = const EdgeInsets.fromLTRB(16, 18, 16, 16),
   });
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    return Material(
-      color: theme.cardColor,
-      elevation: 2,
-      borderRadius: const BorderRadius.only(
-        topLeft: Radius.circular(12),
-        topRight: Radius.circular(12),
+    final isDark = theme.brightness == Brightness.dark;
+    final borderColor = isDark
+        ? AppColors.darkBorder
+        : theme.colorScheme.onSurface.withOpacity(.08);
+    final shadowColor = isDark
+        ? Colors.black.withOpacity(.4)
+        : Colors.black.withOpacity(.08);
+
+    return Container(
+      decoration: BoxDecoration(
+        boxShadow: [
+          BoxShadow(
+            color: shadowColor,
+            blurRadius: 22,
+            spreadRadius: 0,
+            offset: const Offset(0, -12),
+          ),
+        ],
       ),
-      child: Padding(
-        padding: padding,
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Row(
-              children: [
-                _chip('Размер', Icons.text_fields),
-                const SizedBox(width: 8),
-                Expanded(
-                  child: SliderTheme(
-                    data: SliderTheme.of(context).copyWith(
-                      trackHeight: 2.5,
-                      thumbShape: const RoundSliderThumbShape(
-                        enabledThumbRadius: 8,
+      child: ClipRRect(
+        borderRadius: const BorderRadius.only(
+          topLeft: Radius.circular(20),
+          topRight: Radius.circular(20),
+        ),
+        child: BackdropFilter(
+          filter: ImageFilter.blur(sigmaX: 18, sigmaY: 18),
+          child: DecoratedBox(
+            decoration: BoxDecoration(
+              gradient: LinearGradient(
+                begin: Alignment.topLeft,
+                end: Alignment.bottomRight,
+                colors: [
+                  theme.colorScheme.surface.withOpacity(isDark ? .92 : .86),
+                  theme.colorScheme.surfaceVariant
+                      .withOpacity(isDark ? .88 : .82),
+                ],
+              ),
+              border: Border(
+                top: BorderSide(color: borderColor, width: 1),
+              ),
+            ),
+            child: Padding(
+              padding: padding,
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  _sizeControls(context),
+                  const SizedBox(height: 14),
+                  _segmentedRow(
+                    context: context,
+                    label: _chip('Тема', Icons.palette_outlined),
+                    children: [
+                      _segBtn(
+                        context,
+                        'Светлая',
+                        prefs.theme == ReadingTheme.light,
+                        () => prefs.setTheme(ReadingTheme.light),
                       ),
-                    ),
-                    child: Slider(
-                      min: 12,
-                      max: 28,
-                      divisions: 16,
-                      value: prefs.fontSize,
-                      onChanged: prefs.setSize,
-                    ),
+                      _segBtn(
+                        context,
+                        'Сепия',
+                        prefs.theme == ReadingTheme.sepia,
+                        () => prefs.setTheme(ReadingTheme.sepia),
+                      ),
+                      _segBtn(
+                        context,
+                        'Тёмная',
+                        prefs.theme == ReadingTheme.dark,
+                        () => prefs.setTheme(ReadingTheme.dark),
+                      ),
+                    ],
                   ),
-                ),
-                SizedBox(
-                  width: 32,
-                  child: Text(
-                    prefs.fontSize.round().toString(),
-                    textAlign: TextAlign.right,
-                    style: theme.textTheme.labelMedium,
+                  const SizedBox(height: 14),
+                  _segmentedRow(
+                    context: context,
+                    label: _chip('Шрифт', Icons.font_download_outlined),
+                    children: [
+                      _segBtn(
+                        context,
+                        'Sans',
+                        prefs.font == ReadingFont.sans,
+                        () => prefs.setFont(ReadingFont.sans),
+                      ),
+                      _segBtn(
+                        context,
+                        'Serif',
+                        prefs.font == ReadingFont.serif,
+                        () => prefs.setFont(ReadingFont.serif),
+                      ),
+                      _segBtn(
+                        context,
+                        'Mono',
+                        prefs.font == ReadingFont.mono,
+                        () => prefs.setFont(ReadingFont.mono),
+                      ),
+                      _resetButton(context),
+                    ],
                   ),
-                ),
-              ],
+                ],
+              ),
             ),
-            const SizedBox(height: 6),
-            _hScrollRow(
-              label: _chip('Тема', Icons.palette_outlined),
-              children: [
-                _segBtn(
-                  context,
-                  'Светлая',
-                  prefs.theme == ReadingTheme.light,
-                  () => prefs.setTheme(ReadingTheme.light),
-                ),
-                _segBtn(
-                  context,
-                  'Сепия',
-                  prefs.theme == ReadingTheme.sepia,
-                  () => prefs.setTheme(ReadingTheme.sepia),
-                ),
-                _segBtn(
-                  context,
-                  'Тёмная',
-                  prefs.theme == ReadingTheme.dark,
-                  () => prefs.setTheme(ReadingTheme.dark),
-                ),
-              ],
-            ),
-            const SizedBox(height: 6),
-            _hScrollRow(
-              label: _chip('Шрифт', Icons.font_download_outlined),
-              children: [
-                _segBtn(
-                  context,
-                  'Sans',
-                  prefs.font == ReadingFont.sans,
-                  () => prefs.setFont(ReadingFont.sans),
-                ),
-                _segBtn(
-                  context,
-                  'Serif',
-                  prefs.font == ReadingFont.serif,
-                  () => prefs.setFont(ReadingFont.serif),
-                ),
-                _segBtn(
-                  context,
-                  'Mono',
-                  prefs.font == ReadingFont.mono,
-                  () => prefs.setFont(ReadingFont.mono),
-                ),
-                TextButton(
-                  onPressed: prefs.reset,
-                  child: const Text('Сбросить'),
-                ),
-              ],
-            ),
-          ],
+          ),
         ),
       ),
     );
   }
 
-  static Widget _chip(String text, IconData icon) {
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-      decoration: BoxDecoration(
-        color: AppColors.primary.withOpacity(.12),
-        borderRadius: BorderRadius.circular(999),
-      ),
-      child: Row(
-        children: [
-          Icon(icon, size: 14, color: AppColors.primary),
-          const SizedBox(width: 6),
-          Text(
-            text,
-            style: const TextStyle(
-              color: AppColors.primary,
-              fontWeight: FontWeight.w700,
-              fontSize: 12,
+  Widget _sizeControls(BuildContext context) {
+    final theme = Theme.of(context);
+    final sliderTheme = SliderTheme.of(context).copyWith(
+      trackHeight: 3,
+      activeTrackColor: AppColors.primary,
+      inactiveTrackColor: theme.colorScheme.onSurface.withOpacity(.12),
+      thumbColor: AppColors.primary,
+      overlayShape: SliderComponentShape.noOverlay,
+      thumbShape: const RoundSliderThumbShape(enabledThumbRadius: 9),
+    );
+
+    return Row(
+      children: [
+        _chip('Размер', Icons.text_fields),
+        const SizedBox(width: 12),
+        Expanded(
+          child: SliderTheme(
+            data: sliderTheme,
+            child: Slider(
+              min: 12,
+              max: 28,
+              divisions: 16,
+              value: prefs.fontSize,
+              onChanged: prefs.setSize,
             ),
           ),
-        ],
+        ),
+        const SizedBox(width: 12),
+        Text(
+          '${prefs.fontSize.round()} pt',
+          style: theme.textTheme.labelMedium?.copyWith(
+            fontWeight: FontWeight.w700,
+            color: theme.colorScheme.onSurface.withOpacity(.72),
+          ),
+        ),
+      ],
+    );
+  }
+
+  static Widget _chip(String text, IconData icon) {
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(999),
+        border: Border.all(color: AppColors.border.withOpacity(.7)),
+        gradient: const LinearGradient(
+          colors: [
+            Color(0x266366F1),
+            Color(0x268B5CF6),
+          ],
+        ),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(icon, size: 14, color: AppColors.primary),
+            const SizedBox(width: 6),
+            Text(
+              text,
+              style: const TextStyle(
+                color: AppColors.primary,
+                fontWeight: FontWeight.w700,
+                fontSize: 12,
+              ),
+            ),
+          ],
+        ),
       ),
     );
   }
@@ -148,31 +205,34 @@ class CompactTextSettingsBar extends StatelessWidget {
     VoidCallback onTap,
   ) {
     final theme = Theme.of(context);
+    final activeBg = AppColors.primary.withOpacity(.16);
+    final inactiveBg = theme.colorScheme.onSurface.withOpacity(.05);
+    final borderColor = active
+        ? AppColors.primary.withOpacity(.45)
+        : theme.colorScheme.onSurface.withOpacity(.08);
     final textColor = active
         ? AppColors.primary
-        : theme.textTheme.bodyMedium?.color ?? theme.colorScheme.onSurface;
+        : theme.colorScheme.onSurface.withOpacity(.78);
+
     return Padding(
-      padding: const EdgeInsets.only(right: 6),
+      padding: const EdgeInsets.only(right: 8),
       child: InkWell(
-        borderRadius: BorderRadius.circular(9),
+        borderRadius: BorderRadius.circular(10),
         onTap: onTap,
-        child: Container(
-          padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+        child: AnimatedContainer(
+          duration: const Duration(milliseconds: 150),
+          curve: Curves.easeOut,
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
           decoration: BoxDecoration(
-            color: active ? AppColors.primary.withOpacity(.12) : Colors.transparent,
-            border: Border.all(
-              color: active
-                  ? AppColors.primary.withOpacity(.3)
-                  : theme.colorScheme.onSurface.withOpacity(.1),
-            ),
-            borderRadius: BorderRadius.circular(9),
+            color: active ? activeBg : inactiveBg,
+            border: Border.all(color: borderColor),
+            borderRadius: BorderRadius.circular(10),
           ),
           child: Text(
             label,
-            style: TextStyle(
-              fontSize: 12,
-              fontWeight: FontWeight.w600,
+            style: theme.textTheme.labelMedium?.copyWith(
               color: textColor,
+              fontWeight: FontWeight.w600,
             ),
           ),
         ),
@@ -180,14 +240,33 @@ class CompactTextSettingsBar extends StatelessWidget {
     );
   }
 
-  static Widget _hScrollRow({
+  Widget _resetButton(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(right: 8),
+      child: TextButton(
+        onPressed: prefs.reset,
+        style: TextButton.styleFrom(
+          foregroundColor: Theme.of(context).colorScheme.onSurface.withOpacity(.72),
+          textStyle: Theme.of(context)
+              .textTheme
+              .labelMedium
+              ?.copyWith(fontWeight: FontWeight.w600),
+        ),
+        child: const Text('Сбросить'),
+      ),
+    );
+  }
+
+  static Widget _segmentedRow({
+    required BuildContext context,
     required Widget label,
     required List<Widget> children,
   }) {
     return Row(
+      crossAxisAlignment: CrossAxisAlignment.center,
       children: [
         label,
-        const SizedBox(width: 8),
+        const SizedBox(width: 14),
         Expanded(
           child: SingleChildScrollView(
             scrollDirection: Axis.horizontal,


### PR DESCRIPTION
## Summary
- restyle the compact text settings bar with glassmorphism treatment and refreshed controls
- anchor the settings bar and action buttons within the chapter edit view bottom area

## Testing
- Not run (Flutter/Dart SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_b_68dc46ed1aac8322ba05eb0e8def52cf