### PR TITLE
Adjust spacing between text settings bar and buttons

### DIFF
--- a/lib/views/chapter_edit_view.dart
+++ b/lib/views/chapter_edit_view.dart
@@ -110,7 +110,6 @@ class _ChapterEditViewState extends State<ChapterEditView> {
             mainAxisSize: MainAxisSize.min,
             children: [
               CompactTextSettingsBar(prefs: prefs),
-              const SizedBox(height: 12),
               Padding(
                 padding: const EdgeInsets.symmetric(horizontal: 16),
                 child: Row(


### PR DESCRIPTION
## Summary
- remove the extra spacer between the text settings bar and action buttons in the chapter edit view so the bar sits directly above the buttons

## Testing
- flutter test *(fails: Flutter SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_b_68dc49475720832286c783667750e374