### PR TITLE
Implement sticky bottom editor chrome

### DIFF
--- a/lib/widgets/compact_text_settings_bar.dart
+++ b/lib/widgets/compact_text_settings_bar.dart
@@ -1,5 +1,3 @@
-import 'dart:ui';
-
 import 'package:flutter/material.dart';
 
 import '../models/reading_prefs.dart';
@@ -12,177 +10,120 @@ class CompactTextSettingsBar extends StatelessWidget {
   const CompactTextSettingsBar({
     super.key,
     required this.prefs,
-    this.padding = const EdgeInsets.fromLTRB(16, 18, 16, 16),
+    this.padding = const EdgeInsets.fromLTRB(12, 8, 12, 8),
   });
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    final isDark = theme.brightness == Brightness.dark;
-    final borderColor = isDark
-        ? AppColors.darkBorder
-        : theme.colorScheme.onSurface.withOpacity(.08);
-    final shadowColor = isDark
-        ? Colors.black.withOpacity(.4)
-        : Colors.black.withOpacity(.08);
-
-    return Container(
-      decoration: BoxDecoration(
-        boxShadow: [
-          BoxShadow(
-            color: shadowColor,
-            blurRadius: 22,
-            spreadRadius: 0,
-            offset: const Offset(0, -12),
-          ),
-        ],
+    return Material(
+      color: Theme.of(context).cardColor,
+      elevation: 2,
+      borderRadius: const BorderRadius.only(
+        topLeft: Radius.circular(12),
+        topRight: Radius.circular(12),
       ),
-      child: ClipRRect(
-        borderRadius: const BorderRadius.only(
-          topLeft: Radius.circular(20),
-          topRight: Radius.circular(20),
-        ),
-        child: BackdropFilter(
-          filter: ImageFilter.blur(sigmaX: 18, sigmaY: 18),
-          child: DecoratedBox(
-            decoration: BoxDecoration(
-              gradient: LinearGradient(
-                begin: Alignment.topLeft,
-                end: Alignment.bottomRight,
-                colors: [
-                  theme.colorScheme.surface.withOpacity(isDark ? .92 : .86),
-                  theme.colorScheme.surfaceVariant
-                      .withOpacity(isDark ? .88 : .82),
-                ],
-              ),
-              border: Border(
-                top: BorderSide(color: borderColor, width: 1),
-              ),
-            ),
-            child: Padding(
-              padding: padding,
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  _sizeControls(context),
-                  const SizedBox(height: 14),
-                  _segmentedRow(
-                    context: context,
-                    label: _chip('Тема', Icons.palette_outlined),
-                    children: [
-                      _segBtn(
-                        context,
-                        'Светлая',
-                        prefs.theme == ReadingTheme.light,
-                        () => prefs.setTheme(ReadingTheme.light),
-                      ),
-                      _segBtn(
-                        context,
-                        'Сепия',
-                        prefs.theme == ReadingTheme.sepia,
-                        () => prefs.setTheme(ReadingTheme.sepia),
-                      ),
-                      _segBtn(
-                        context,
-                        'Тёмная',
-                        prefs.theme == ReadingTheme.dark,
-                        () => prefs.setTheme(ReadingTheme.dark),
-                      ),
-                    ],
+      child: Padding(
+        padding: padding,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Row(
+              children: [
+                _chip('Размер', Icons.text_fields),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: SliderTheme(
+                    data: SliderTheme.of(context).copyWith(
+                      trackHeight: 2.5,
+                      thumbShape:
+                          const RoundSliderThumbShape(enabledThumbRadius: 8),
+                    ),
+                    child: Slider(
+                      min: 12,
+                      max: 28,
+                      divisions: 16,
+                      value: prefs.fontSize,
+                      onChanged: prefs.setSize,
+                    ),
                   ),
-                  const SizedBox(height: 14),
-                  _segmentedRow(
-                    context: context,
-                    label: _chip('Шрифт', Icons.font_download_outlined),
-                    children: [
-                      _segBtn(
-                        context,
-                        'Sans',
-                        prefs.font == ReadingFont.sans,
-                        () => prefs.setFont(ReadingFont.sans),
-                      ),
-                      _segBtn(
-                        context,
-                        'Serif',
-                        prefs.font == ReadingFont.serif,
-                        () => prefs.setFont(ReadingFont.serif),
-                      ),
-                      _segBtn(
-                        context,
-                        'Mono',
-                        prefs.font == ReadingFont.mono,
-                        () => prefs.setFont(ReadingFont.mono),
-                      ),
-                      _resetButton(context),
-                    ],
+                ),
+                SizedBox(
+                  width: 32,
+                  child: Text(
+                    prefs.fontSize.round().toString(),
+                    textAlign: TextAlign.right,
+                    style: Theme.of(context).textTheme.labelMedium,
                   ),
-                ],
-              ),
+                ),
+              ],
             ),
-          ),
-        ),
-      ),
-    );
-  }
-
-  Widget _sizeControls(BuildContext context) {
-    final theme = Theme.of(context);
-    final sliderTheme = SliderTheme.of(context).copyWith(
-      trackHeight: 3,
-      activeTrackColor: AppColors.primary,
-      inactiveTrackColor: theme.colorScheme.onSurface.withOpacity(.12),
-      thumbColor: AppColors.primary,
-      overlayShape: SliderComponentShape.noOverlay,
-      thumbShape: const RoundSliderThumbShape(enabledThumbRadius: 9),
-    );
-
-    return Row(
-      children: [
-        _chip('Размер', Icons.text_fields),
-        const SizedBox(width: 12),
-        Expanded(
-          child: SliderTheme(
-            data: sliderTheme,
-            child: Slider(
-              min: 12,
-              max: 28,
-              divisions: 16,
-              value: prefs.fontSize,
-              onChanged: prefs.setSize,
+            const SizedBox(height: 6),
+            _hScrollRow(
+              label: _chip('Тема', Icons.palette_outlined),
+              children: [
+                _segBtn(
+                  context,
+                  'Светлая',
+                  prefs.theme == ReadingTheme.light,
+                  () => prefs.setTheme(ReadingTheme.light),
+                ),
+                _segBtn(
+                  context,
+                  'Сепия',
+                  prefs.theme == ReadingTheme.sepia,
+                  () => prefs.setTheme(ReadingTheme.sepia),
+                ),
+                _segBtn(
+                  context,
+                  'Тёмная',
+                  prefs.theme == ReadingTheme.dark,
+                  () => prefs.setTheme(ReadingTheme.dark),
+                ),
+              ],
             ),
-          ),
-        ),
-        const SizedBox(width: 12),
-        Text(
-          '${prefs.fontSize.round()} pt',
-          style: theme.textTheme.labelMedium?.copyWith(
-            fontWeight: FontWeight.w700,
-            color: theme.colorScheme.onSurface.withOpacity(.72),
-          ),
-        ),
-      ],
-    );
-  }
-
-  static Widget _chip(String text, IconData icon) {
-    return DecoratedBox(
-      decoration: BoxDecoration(
-        borderRadius: BorderRadius.circular(999),
-        border: Border.all(color: AppColors.border.withOpacity(.7)),
-        gradient: const LinearGradient(
-          colors: [
-            Color(0x266366F1),
-            Color(0x268B5CF6),
+            const SizedBox(height: 6),
+            _hScrollRow(
+              label: _chip('Шрифт', Icons.font_download_outlined),
+              children: [
+                _segBtn(
+                  context,
+                  'Sans',
+                  prefs.font == ReadingFont.sans,
+                  () => prefs.setFont(ReadingFont.sans),
+                ),
+                _segBtn(
+                  context,
+                  'Serif',
+                  prefs.font == ReadingFont.serif,
+                  () => prefs.setFont(ReadingFont.serif),
+                ),
+                _segBtn(
+                  context,
+                  'Mono',
+                  prefs.font == ReadingFont.mono,
+                  () => prefs.setFont(ReadingFont.mono),
+                ),
+                TextButton(
+                  onPressed: prefs.reset,
+                  child: const Text('Сбросить'),
+                ),
+              ],
+            ),
           ],
         ),
       ),
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+    );
+  }
+
+  static Widget _chip(String text, IconData ic) => Container(
+        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+        decoration: BoxDecoration(
+          color: AppColors.primary.withOpacity(.12),
+          borderRadius: BorderRadius.circular(999),
+        ),
         child: Row(
-          mainAxisSize: MainAxisSize.min,
           children: [
-            Icon(icon, size: 14, color: AppColors.primary),
+            Icon(ic, size: 14, color: AppColors.primary),
             const SizedBox(width: 6),
             Text(
               text,
@@ -194,86 +135,62 @@ class CompactTextSettingsBar extends StatelessWidget {
             ),
           ],
         ),
-      ),
-    );
-  }
+      );
 
   static Widget _segBtn(
-    BuildContext context,
+    BuildContext ctx,
     String label,
     bool active,
     VoidCallback onTap,
-  ) {
-    final theme = Theme.of(context);
-    final activeBg = AppColors.primary.withOpacity(.16);
-    final inactiveBg = theme.colorScheme.onSurface.withOpacity(.05);
-    final borderColor = active
-        ? AppColors.primary.withOpacity(.45)
-        : theme.colorScheme.onSurface.withOpacity(.08);
-    final textColor = active
-        ? AppColors.primary
-        : theme.colorScheme.onSurface.withOpacity(.78);
-
-    return Padding(
-      padding: const EdgeInsets.only(right: 8),
-      child: InkWell(
-        borderRadius: BorderRadius.circular(10),
-        onTap: onTap,
-        child: AnimatedContainer(
-          duration: const Duration(milliseconds: 150),
-          curve: Curves.easeOut,
-          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-          decoration: BoxDecoration(
-            color: active ? activeBg : inactiveBg,
-            border: Border.all(color: borderColor),
-            borderRadius: BorderRadius.circular(10),
-          ),
-          child: Text(
-            label,
-            style: theme.textTheme.labelMedium?.copyWith(
-              color: textColor,
-              fontWeight: FontWeight.w600,
+  ) =>
+      Padding(
+        padding: const EdgeInsets.only(right: 6),
+        child: InkWell(
+          borderRadius: BorderRadius.circular(9),
+          onTap: onTap,
+          child: Container(
+            padding:
+                const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+            decoration: BoxDecoration(
+              color: active
+                  ? AppColors.primary.withOpacity(.12)
+                  : Colors.transparent,
+              border: Border.all(
+                color: active
+                    ? AppColors.primary.withOpacity(.3)
+                    : Theme.of(ctx).dividerColor.withOpacity(.2),
+              ),
+              borderRadius: BorderRadius.circular(9),
+            ),
+            child: Text(
+              label,
+              style: TextStyle(
+                fontSize: 12,
+                fontWeight: FontWeight.w600,
+                color: active
+                    ? AppColors.primary
+                    : Theme.of(ctx).textTheme.bodyMedium?.color ??
+                        Theme.of(ctx).colorScheme.onSurface,
+              ),
             ),
           ),
         ),
-      ),
-    );
-  }
+      );
 
-  Widget _resetButton(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.only(right: 8),
-      child: TextButton(
-        onPressed: prefs.reset,
-        style: TextButton.styleFrom(
-          foregroundColor: Theme.of(context).colorScheme.onSurface.withOpacity(.72),
-          textStyle: Theme.of(context)
-              .textTheme
-              .labelMedium
-              ?.copyWith(fontWeight: FontWeight.w600),
-        ),
-        child: const Text('Сбросить'),
-      ),
-    );
-  }
-
-  static Widget _segmentedRow({
-    required BuildContext context,
+  static Widget _hScrollRow({
     required Widget label,
     required List<Widget> children,
-  }) {
-    return Row(
-      crossAxisAlignment: CrossAxisAlignment.center,
-      children: [
-        label,
-        const SizedBox(width: 14),
-        Expanded(
-          child: SingleChildScrollView(
-            scrollDirection: Axis.horizontal,
-            child: Row(children: children),
+  }) =>
+      Row(
+        children: [
+          label,
+          const SizedBox(width: 8),
+          Expanded(
+            child: SingleChildScrollView(
+              scrollDirection: Axis.horizontal,
+              child: Row(children: children),
+            ),
           ),
-        ),
-      ],
-    );
-  }
+        ],
+      );
 }

--- a/lib/widgets/measure_size.dart
+++ b/lib/widgets/measure_size.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/rendering.dart';
+import 'package:flutter/widgets.dart';
+
+typedef OnWidgetSizeChange = void Function(Size size);
+
+/// Оборачивает любой виджет и сообщает его фактический размер через [onChange].
+/// Без лейаут-артефактов, выстреливает при каждом изменении.
+class MeasureSize extends SingleChildRenderObjectWidget {
+  final OnWidgetSizeChange onChange;
+
+  const MeasureSize({super.key, required this.onChange, required Widget child})
+      : super(child: child);
+
+  @override
+  RenderObject createRenderObject(BuildContext context) =>
+      _RenderMeasureSize(onChange);
+}
+
+class _RenderMeasureSize extends RenderProxyBox {
+  _RenderMeasureSize(this.onChange);
+
+  final OnWidgetSizeChange onChange;
+  Size? _oldSize;
+
+  @override
+  void performLayout() {
+    super.performLayout();
+    final newSize = child?.size;
+    if (newSize == null) return;
+    if (_oldSize == newSize) return;
+    _oldSize = newSize;
+    WidgetsBinding.instance.addPostFrameCallback((_) => onChange(newSize));
+  }
+}


### PR DESCRIPTION
## Summary
- rework ChapterEditView to use a stacked layout with sticky bottom controls that lift above the keyboard and pad the editor dynamically
- add a reusable MeasureSize render object to report runtime widget sizes for layout adjustments
- refresh the compact text settings bar styling to match the lightweight bottom chrome

## Testing
- not run (Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_b_68dc4bef0ad08322abdc255529ca6f56