### PR TITLE
Add themed chrome helpers for reading views

### DIFF
--- a/lib/models/reading_prefs.dart
+++ b/lib/models/reading_prefs.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import '../shared/tokens/design_tokens.dart'; // для AppColors.primary
 
 enum ReadingTheme { light, sepia, dark }
 enum ReadingFont { sans, serif, mono }
@@ -78,5 +79,44 @@ class ReadingPrefs extends ChangeNotifier {
       case ReadingFont.mono:
         return const ['Menlo', 'Consolas', 'Roboto Mono'];
     }
+  }
+
+  // ====== Chrome (верх/низ панелей) ======
+  bool get isDark => theme == ReadingTheme.dark;
+
+  /// База под панели: чуть светлее фон текста
+  Color get chromeBase {
+    final double k = switch (theme) {
+      ReadingTheme.dark => 0.10,
+      ReadingTheme.sepia => 0.06,
+      ReadingTheme.light => 0.04,
+    };
+    return Color.lerp(bgColor, Colors.white, k)!;
+  }
+
+  /// Контур панелей
+  Color get chromeBorder =>
+      isDark ? Colors.white.withOpacity(.08) : Colors.black.withOpacity(.06);
+
+  /// Цвет иконок/текстов на AppBar
+  Color get chromeForeground =>
+      isDark ? Colors.white : const Color(0xFF111827);
+
+  /// Градиент панелей (легкая лавандово-бирюзовая вуаль поверх chromeBase)
+  LinearGradient get chromeGradient {
+    // Легкая лавандово-бирюзовая вуаль поверх chromeBase
+    final c1 = Color.alphaBlend(
+      AppColors.primary.withOpacity(0.16),
+      chromeBase,
+    );
+    final c2 = Color.alphaBlend(
+      AppColors.accent.withOpacity(0.12),
+      chromeBase,
+    );
+    return LinearGradient(
+      begin: Alignment.topLeft,
+      end: Alignment.bottomRight,
+      colors: [c1, c2],
+    );
   }
 }

--- a/lib/views/chapter_edit_view.dart
+++ b/lib/views/chapter_edit_view.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
 import '../models/chapter.dart';
 import '../models/reading_prefs.dart';
@@ -89,6 +90,13 @@ class _ChapterEditViewState extends State<ChapterEditView> {
     return Scaffold(
       resizeToAvoidBottomInset: false,
       appBar: AppBar(
+        backgroundColor: Colors.transparent,
+        elevation: 2,
+        foregroundColor: prefs.chromeForeground,
+        systemOverlayStyle:
+            prefs.isDark ? SystemUiOverlayStyle.light : SystemUiOverlayStyle.dark,
+        flexibleSpace:
+            Container(decoration: BoxDecoration(gradient: prefs.chromeGradient)),
         leading: IconButton(
           icon: const Icon(Icons.arrow_back),
           tooltip: 'Назад',
@@ -156,49 +164,52 @@ class _ChapterEditViewState extends State<ChapterEditView> {
                   child: Column(
                     mainAxisSize: MainAxisSize.min,
                     children: [
+                      // Панель настроек сама рисует фон и обводку
                       CompactTextSettingsBar(prefs: prefs),
+                      // Кнопки действий в том же стиле
                       Material(
-                        color: theme.colorScheme.surface,
+                        color: Colors.transparent,
                         elevation: 2,
-                        child: Container(
-                          padding: const EdgeInsets.fromLTRB(16, 8, 16, 8),
+                        child: DecoratedBox(
                           decoration: BoxDecoration(
-                            border: Border(
-                              top: BorderSide(color: theme.dividerColor.withOpacity(.12)),
-                            ),
+                            gradient: prefs.chromeGradient,
+                            border: Border(top: BorderSide(color: prefs.chromeBorder)),
                           ),
-                          child: Row(
-                            children: [
-                              Expanded(
-                                child: OutlinedButton.icon(
-                                  onPressed: widget.onEditMode ?? () {},
-                                  icon: const Icon(Icons.edit_outlined),
-                                  label: const Text('Редактировать'),
-                                  style: OutlinedButton.styleFrom(
-                                    padding: const EdgeInsets.symmetric(vertical: 12),
-                                    shape: RoundedRectangleBorder(
-                                      borderRadius: BorderRadius.circular(12),
+                          child: Container(
+                            padding: const EdgeInsets.fromLTRB(16, 8, 16, 8),
+                            child: Row(
+                              children: [
+                                Expanded(
+                                  child: OutlinedButton.icon(
+                                    onPressed: widget.onEditMode ?? () {},
+                                    icon: const Icon(Icons.edit_outlined),
+                                    label: const Text('Редактировать'),
+                                    style: OutlinedButton.styleFrom(
+                                      padding: const EdgeInsets.symmetric(vertical: 12),
+                                      shape: RoundedRectangleBorder(
+                                        borderRadius: BorderRadius.circular(12),
+                                      ),
                                     ),
                                   ),
                                 ),
-                              ),
-                              const SizedBox(width: 10),
-                              Expanded(
-                                child: ElevatedButton.icon(
-                                  onPressed: widget.onVoice ?? () {},
-                                  icon: const Icon(Icons.graphic_eq_rounded),
-                                  label: const Text('Озвучить'),
-                                  style: ElevatedButton.styleFrom(
-                                    backgroundColor: AppColors.primary,
-                                    foregroundColor: Colors.white,
-                                    padding: const EdgeInsets.symmetric(vertical: 12),
-                                    shape: RoundedRectangleBorder(
-                                      borderRadius: BorderRadius.circular(12),
+                                const SizedBox(width: 10),
+                                Expanded(
+                                  child: ElevatedButton.icon(
+                                    onPressed: widget.onVoice ?? () {},
+                                    icon: const Icon(Icons.graphic_eq_rounded),
+                                    label: const Text('Озвучить'),
+                                    style: ElevatedButton.styleFrom(
+                                      backgroundColor: AppColors.primary,
+                                      foregroundColor: Colors.white,
+                                      padding: const EdgeInsets.symmetric(vertical: 12),
+                                      shape: RoundedRectangleBorder(
+                                        borderRadius: BorderRadius.circular(12),
+                                      ),
                                     ),
                                   ),
                                 ),
-                              ),
-                            ],
+                              ],
+                            ),
                           ),
                         ),
                       ),

--- a/lib/views/chapter_read_view.dart
+++ b/lib/views/chapter_read_view.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
 import '../models/chapter.dart';
 import '../models/reading_prefs.dart';
@@ -94,6 +95,13 @@ class _ChapterReadViewState extends State<ChapterReadView> {
     return Scaffold(
       resizeToAvoidBottomInset: false,
       appBar: AppBar(
+        backgroundColor: Colors.transparent,
+        elevation: 2,
+        foregroundColor: prefs.chromeForeground,
+        systemOverlayStyle:
+            prefs.isDark ? SystemUiOverlayStyle.light : SystemUiOverlayStyle.dark,
+        flexibleSpace:
+            Container(decoration: BoxDecoration(gradient: prefs.chromeGradient)),
         leading: IconButton(
           icon: const Icon(Icons.arrow_back),
           tooltip: 'Назад',
@@ -152,43 +160,48 @@ class _ChapterReadViewState extends State<ChapterReadView> {
                   child: Column(
                     mainAxisSize: MainAxisSize.min,
                     children: [
+                      // Компактная панель настроек чтения уже содержит градиент и обводку
                       CompactTextSettingsBar(prefs: prefs),
+                      // Кнопки действий — под ту же тему
                       Material(
-                        color: Theme.of(context).cardColor,
+                        color: Colors.transparent,
                         elevation: 2,
-                        child: Container(
-                          padding: const EdgeInsets.fromLTRB(16, 8, 16, 8),
+                        child: DecoratedBox(
                           decoration: BoxDecoration(
-                            border: Border(top: BorderSide(color: Theme.of(context).dividerColor.withOpacity(.4))),
+                            gradient: prefs.chromeGradient,
+                            border: Border(top: BorderSide(color: prefs.chromeBorder)),
                           ),
-                          child: Row(
-                            children: [
-                              Expanded(
-                                child: OutlinedButton.icon(
-                                  onPressed: widget.onEdit,
-                                  icon: const Icon(Icons.edit_outlined),
-                                  label: const Text('Редактировать'),
-                                  style: OutlinedButton.styleFrom(
-                                    padding: const EdgeInsets.symmetric(vertical: 12),
-                                    shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+                          child: Container(
+                            padding: const EdgeInsets.fromLTRB(16, 8, 16, 8),
+                            child: Row(
+                              children: [
+                                Expanded(
+                                  child: OutlinedButton.icon(
+                                    onPressed: widget.onEdit,
+                                    icon: const Icon(Icons.edit_outlined),
+                                    label: const Text('Редактировать'),
+                                    style: OutlinedButton.styleFrom(
+                                      padding: const EdgeInsets.symmetric(vertical: 12),
+                                      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+                                    ),
                                   ),
                                 ),
-                              ),
-                              const SizedBox(width: 10),
-                              Expanded(
-                                child: ElevatedButton.icon(
-                                  onPressed: widget.onVoice,
-                                  icon: const Icon(Icons.graphic_eq_rounded),
-                                  label: const Text('Озвучить'),
-                                  style: ElevatedButton.styleFrom(
-                                    backgroundColor: AppColors.primary,
-                                    foregroundColor: Colors.white,
-                                    padding: const EdgeInsets.symmetric(vertical: 12),
-                                    shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+                                const SizedBox(width: 10),
+                                Expanded(
+                                  child: ElevatedButton.icon(
+                                    onPressed: widget.onVoice,
+                                    icon: const Icon(Icons.graphic_eq_rounded),
+                                    label: const Text('Озвучить'),
+                                    style: ElevatedButton.styleFrom(
+                                      backgroundColor: AppColors.primary,
+                                      foregroundColor: Colors.white,
+                                      padding: const EdgeInsets.symmetric(vertical: 12),
+                                      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+                                    ),
                                   ),
                                 ),
-                              ),
-                            ],
+                              ],
+                            ),
                           ),
                         ),
                       ),

--- a/lib/widgets/compact_text_settings_bar.dart
+++ b/lib/widgets/compact_text_settings_bar.dart
@@ -16,18 +16,23 @@ class CompactTextSettingsBar extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Material(
-      color: Theme.of(context).cardColor,
+      color: Colors.transparent,
       elevation: 2,
-      borderRadius: const BorderRadius.only(
-        topLeft: Radius.circular(12),
-        topRight: Radius.circular(12),
-      ),
-      child: Padding(
-        padding: padding,
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Row(
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          gradient: prefs.chromeGradient,
+          border: Border(top: BorderSide(color: prefs.chromeBorder)),
+          borderRadius: const BorderRadius.only(
+            topLeft: Radius.circular(12),
+            topRight: Radius.circular(12),
+          ),
+        ),
+        child: Padding(
+          padding: padding,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Row(
               children: [
                 _chip('Размер', Icons.text_fields),
                 const SizedBox(width: 8),
@@ -109,7 +114,8 @@ class CompactTextSettingsBar extends StatelessWidget {
                 ),
               ],
             ),
-          ],
+            ],
+          ),
         ),
       ),
     );


### PR DESCRIPTION
## Summary
- add chrome styling helpers to `ReadingPrefs` to provide consistent chrome colors and gradients
- update the compact text settings bar and reading/edit action bars to use the new gradient chrome styling
- apply themed app bar styling and overlay colors in the reading and editing chapter screens

## Testing
- not run (UI changes only)


------
https://chatgpt.com/codex/tasks/task_b_68dc51a0cb6c8322812214d2dd055fb4