### PR TITLE
Fix AppBar tint overlay

### DIFF
--- a/lib/views/chapter_edit_view.dart
+++ b/lib/views/chapter_edit_view.dart
@@ -91,12 +91,16 @@ class _ChapterEditViewState extends State<ChapterEditView> {
       resizeToAvoidBottomInset: false,
       appBar: AppBar(
         backgroundColor: Colors.transparent,
+        surfaceTintColor: Colors.transparent,
         elevation: 2,
+        scrolledUnderElevation: 0,
+        shadowColor: Colors.transparent,
         foregroundColor: prefs.chromeForeground,
         systemOverlayStyle:
             prefs.isDark ? SystemUiOverlayStyle.light : SystemUiOverlayStyle.dark,
-        flexibleSpace:
-            Container(decoration: BoxDecoration(gradient: prefs.chromeGradient)),
+        flexibleSpace: DecoratedBox(
+          decoration: BoxDecoration(gradient: prefs.chromeGradient),
+        ),
         leading: IconButton(
           icon: const Icon(Icons.arrow_back),
           tooltip: 'Назад',

--- a/lib/views/chapter_read_view.dart
+++ b/lib/views/chapter_read_view.dart
@@ -95,13 +95,18 @@ class _ChapterReadViewState extends State<ChapterReadView> {
     return Scaffold(
       resizeToAvoidBottomInset: false,
       appBar: AppBar(
+        // ВАЖНО: отключаем tint/overlay у M3 и красим градиентом из prefs
         backgroundColor: Colors.transparent,
+        surfaceTintColor: Colors.transparent,
         elevation: 2,
+        scrolledUnderElevation: 0,
+        shadowColor: Colors.transparent,
         foregroundColor: prefs.chromeForeground,
         systemOverlayStyle:
             prefs.isDark ? SystemUiOverlayStyle.light : SystemUiOverlayStyle.dark,
-        flexibleSpace:
-            Container(decoration: BoxDecoration(gradient: prefs.chromeGradient)),
+        flexibleSpace: DecoratedBox(
+          decoration: BoxDecoration(gradient: prefs.chromeGradient),
+        ),
         leading: IconButton(
           icon: const Icon(Icons.arrow_back),
           tooltip: 'Назад',


### PR DESCRIPTION
## Summary
- disable Material 3 surface tint and overlay on chapter read/edit app bars
- render the configured chrome gradient within flexibleSpace for consistent appearance

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68dc541c912083229e0c9ce70c89c3c2