### PR TITLE
Make reading progress bar use reading theme

### DIFF
--- a/lib/views/chapter_read_view.dart
+++ b/lib/views/chapter_read_view.dart
@@ -113,7 +113,11 @@ class _ChapterReadViewState extends State<ChapterReadView> {
                 words: widget.chapter.words,
                 prefs: prefs,
               ),
-              ReadingProgressBar(progress: progress, words: widget.chapter.words),
+              ReadingProgressBar(
+                progress: progress,
+                words: widget.chapter.words,
+                prefs: prefs,
+              ),
               Expanded(
                 child: Container(
                   color: prefs.bgColor,

--- a/lib/widgets/reading_progress_bar.dart
+++ b/lib/widgets/reading_progress_bar.dart
@@ -1,24 +1,24 @@
 import 'package:flutter/material.dart';
 
-import '../shared/tokens/design_tokens.dart';
+import '../models/reading_prefs.dart';
 
 class ReadingProgressBar extends StatelessWidget {
   final double progress;
   final int words;
+  final ReadingPrefs prefs;
 
   const ReadingProgressBar({
     super.key,
     required this.progress,
     required this.words,
+    required this.prefs,
   });
 
   @override
   Widget build(BuildContext context) {
     final pct = (progress * 100).clamp(0, 100).round();
-    final theme = Theme.of(context);
-    final textTheme = theme.textTheme;
-    final onSurface = theme.colorScheme.onSurface.withOpacity(.55);
-    final trackColor = theme.colorScheme.onSurface.withOpacity(.08);
+    final onColor = prefs.textColor;
+    final subColor = onColor.withOpacity(.60);
     return Padding(
       padding: const EdgeInsets.fromLTRB(16, 8, 16, 12),
       child: Column(
@@ -28,28 +28,16 @@ class ReadingProgressBar extends StatelessWidget {
             children: [
               Text(
                 'Прогресс чтения',
-                style: textTheme.titleSmall?.copyWith(fontWeight: FontWeight.w700) ??
-                    const TextStyle(fontWeight: FontWeight.w700),
+                style: TextStyle(fontWeight: FontWeight.w700, color: onColor),
               ),
               const Spacer(),
-              Text('$pct%'),
+              Text('$pct%', style: TextStyle(color: onColor)),
             ],
           ),
           const SizedBox(height: 8),
-          ClipRRect(
-            borderRadius: BorderRadius.circular(999),
-            child: LinearProgressIndicator(
-              value: progress.clamp(0, 1).toDouble(),
-              minHeight: 8,
-              backgroundColor: trackColor,
-              valueColor: const AlwaysStoppedAnimation<Color>(AppColors.primary),
-            ),
-          ),
+          _GradientProgress(value: progress.clamp(0, 1).toDouble(), prefs: prefs),
           const SizedBox(height: 6),
-          Text(
-            '${_fmt(words)} слов',
-            style: textTheme.bodySmall?.copyWith(color: onSurface) ?? TextStyle(color: onSurface),
-          ),
+          Text('${_fmt(words)} слов', style: TextStyle(color: subColor)),
         ],
       ),
     );
@@ -64,5 +52,41 @@ class ReadingProgressBar extends StatelessWidget {
       if (p > 1 && p % 3 == 1) buf.write(' ');
     }
     return buf.toString();
+  }
+}
+
+class _GradientProgress extends StatelessWidget {
+  final double value;
+  final ReadingPrefs prefs;
+
+  const _GradientProgress({required this.value, required this.prefs});
+
+  @override
+  Widget build(BuildContext context) {
+    final track = prefs.isDark
+        ? Colors.white.withOpacity(.16)
+        : Colors.black.withOpacity(.08);
+
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(999),
+      child: SizedBox(
+        height: 8,
+        child: Stack(
+          fit: StackFit.expand,
+          children: [
+            Container(color: track),
+            Align(
+              alignment: Alignment.centerLeft,
+              child: FractionallySizedBox(
+                widthFactor: value.isNaN ? 0 : value,
+                child: DecoratedBox(
+                  decoration: BoxDecoration(gradient: prefs.chromeGradient),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
   }
 }


### PR DESCRIPTION
## Summary
- update the reading progress bar to use reading preferences for colors and gradient fill
- pass the current reading preferences into the progress bar from the chapter view

## Testing
- Not run (tooling unavailable)

------
https://chatgpt.com/codex/tasks/task_b_68dc57ceb70c8322aace6c1490e8bd35