### PR TITLE
Fix reading progress background theme mismatch

### DIFF
--- a/lib/views/chapter_read_view.dart
+++ b/lib/views/chapter_read_view.dart
@@ -113,10 +113,16 @@ class _ChapterReadViewState extends State<ChapterReadView> {
                 words: widget.chapter.words,
                 prefs: prefs,
               ),
-              ReadingProgressBar(
-                progress: progress,
-                words: widget.chapter.words,
-                prefs: prefs,
+              DecoratedBox(
+                decoration: BoxDecoration(
+                  color: prefs.bgColor,
+                  border: Border(top: BorderSide(color: prefs.chromeBorder)),
+                ),
+                child: ReadingProgressBar(
+                  progress: progress,
+                  words: widget.chapter.words,
+                  prefs: prefs,
+                ),
               ),
               Expanded(
                 child: Container(


### PR DESCRIPTION
## Summary
- wrap the reading progress bar in a themed DecoratedBox so its background follows the reading prefs

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68dc5977f38c8322820963ed0f34e693