### PR TITLE
Use Google Fonts for reading typography

### DIFF
--- a/lib/models/reading_prefs.dart
+++ b/lib/models/reading_prefs.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+
 import '../shared/tokens/design_tokens.dart'; // для AppColors.primary
 
 enum ReadingTheme { light, sepia, dark }
@@ -78,6 +80,21 @@ class ReadingPrefs extends ChangeNotifier {
         return const ['Georgia', 'Times New Roman', 'Noto Serif', 'RobotoSlab'];
       case ReadingFont.mono:
         return const ['Menlo', 'Consolas', 'Roboto Mono'];
+    }
+  }
+
+  /// Готовый стиль для основного текста чтения/редактирования с выбранным шрифтом.
+  TextStyle bodyTextStyle({
+    required double fontSize,
+    required Color color,
+  }) {
+    switch (font) {
+      case ReadingFont.sans:
+        return GoogleFonts.inter(fontSize: fontSize, height: 1.6, color: color);
+      case ReadingFont.serif:
+        return GoogleFonts.merriweather(fontSize: fontSize, height: 1.7, color: color);
+      case ReadingFont.mono:
+        return GoogleFonts.jetbrainsMono(fontSize: fontSize, height: 1.5, color: color);
     }
   }
 

--- a/lib/views/chapter_edit_view.dart
+++ b/lib/views/chapter_edit_view.dart
@@ -72,12 +72,9 @@ class _ChapterEditViewState extends State<ChapterEditView> {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final editorStyle = TextStyle(
+    final editorStyle = prefs.bodyTextStyle(
       fontSize: prefs.fontSize,
-      height: 1.6,
       color: prefs.textColor,
-      fontFamily: prefs.fontFamily,
-      fontFamilyFallback: prefs.fontFallback,
     );
 
     final viewInsets = MediaQuery.of(context).viewInsets.bottom;

--- a/lib/views/chapter_read_view.dart
+++ b/lib/views/chapter_read_view.dart
@@ -301,12 +301,9 @@ class _ReadingBody extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final style = TextStyle(
+    final style = prefs.bodyTextStyle(
       fontSize: prefs.fontSize,
-      height: 1.6,
       color: prefs.textColor,
-      fontFamily: prefs.fontFamily,
-      fontFamilyFallback: prefs.fontFallback,
     );
     return Text(text.trim(), style: style);
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,6 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  google_fonts: ^6.2.1
   flutter_localizations:
     sdk: flutter
   go_router: ^16.2.4


### PR DESCRIPTION
## Summary
- add the google_fonts dependency to supply bundled Inter, Merriweather, and JetBrains Mono faces
- expose a ReadingPrefs.bodyTextStyle helper that returns the proper Google Font for the current preference
- update chapter read and edit views to consume the helper so Sans/Serif/Mono switches the visible font

## Testing
- flutter pub get *(fails: Flutter SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_b_68dcd7bdef7483229ebbc99547b0f5b9