### PR TITLE
Fix JetBrains Mono font helper name

### DIFF
--- a/lib/models/reading_prefs.dart
+++ b/lib/models/reading_prefs.dart
@@ -94,7 +94,11 @@ class ReadingPrefs extends ChangeNotifier {
       case ReadingFont.serif:
         return GoogleFonts.merriweather(fontSize: fontSize, height: 1.7, color: color);
       case ReadingFont.mono:
-        return GoogleFonts.jetbrainsMono(fontSize: fontSize, height: 1.5, color: color);
+        return GoogleFonts.jetBrainsMono(
+          fontSize: fontSize,
+          height: 1.5,
+          color: color,
+        );
     }
   }
 


### PR DESCRIPTION
## Summary
- correct the GoogleFonts helper used for the mono reading font to the proper `jetBrainsMono`

## Testing
- flutter analyze *(fails: `flutter` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_b_68dcd91c676c8322a8b4b8aeae0281bd